### PR TITLE
Inline Publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cmd/mqtt

--- a/examples/events/main.go
+++ b/examples/events/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/logrusorgru/aurora"
+
+	mqtt "github.com/mochi-co/mqtt/server"
+	"github.com/mochi-co/mqtt/server/listeners"
+	"github.com/mochi-co/mqtt/server/listeners/auth"
+)
+
+func main() {
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		done <- true
+	}()
+
+	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("TCP"))
+
+	server := mqtt.New()
+	tcp := listeners.NewTCP("t1", ":1883")
+	err := server.AddListener(tcp, &listeners.Config{
+		Auth: new(auth.Allow),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Start the server
+	go func() {
+		err := server.Serve()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// Demonstration of directly publishing messages to a topic via the
+	// `server.Publish` method. Subscribe to `direct/publish` using your
+	// MQTT client to see the messages.
+	go func() {
+		for range time.Tick(time.Second * 5) {
+			server.Publish("direct/publish", []byte("hello world"), false)
+			fmt.Println("> issued direct message to direct/publish")
+		}
+	}()
+
+	fmt.Println(aurora.BgMagenta("  Started!  "))
+
+	<-done
+	fmt.Println(aurora.BgRed("  Caught Signal  "))
+
+	server.Close()
+	fmt.Println(aurora.BgGreen("  Finished  "))
+}

--- a/server/internal/circ/writer.go
+++ b/server/internal/circ/writer.go
@@ -77,6 +77,7 @@ func (b *Writer) WriteTo(w io.Writer) (total int, err error) {
 }
 
 // Write writes the buffer to the buffer p, returning the number of bytes written.
+// The bytes written to the buffer are picked up by WriteTo.
 func (b *Writer) Write(p []byte) (total int, err error) {
 	err = b.awaitEmpty(len(p))
 	if err != nil {

--- a/server/listeners/tcp.go
+++ b/server/listeners/tcp.go
@@ -80,8 +80,8 @@ func (l *TCP) Listen(s *system.Info) error {
 	return nil
 }
 
-// Serve starts waiting for new TCP connections, and calls the connection
-// establishment callback for any received.
+// Serve starts waiting for new TCP connections, and calls the establish
+// connection callback for any received.
 func (l *TCP) Serve(establish EstablishFunc) {
 	for {
 		if atomic.LoadInt64(&l.end) == 1 {


### PR DESCRIPTION
Adds the ability to directly publish messages from the embedding service using the `func (s *Server) Publish(topic string, payload []byte, retain bool) error` method.

Also provides various commentary cleanups for clarity.