### PR TITLE
Add AllowClients Field to packets

### DIFF
--- a/examples/events/main.go
+++ b/examples/events/main.go
@@ -54,6 +54,12 @@ func main() {
 			fmt.Printf("< OnMessage received message from client %s: %s\n", cl.ID, string(pkx.Payload))
 		}
 
+		// Example of using AllowClients to selectively deliver/drop messages.
+		// Only a client with the id of `allowed-client` will received messages on the topic.
+		if pkx.TopicName == "a/b/restricted" {
+			pkx.AllowClients = []string{"allowed-client"} // slice of known client ids
+		}
+
 		return pkx, nil
 	}
 

--- a/server/internal/clients/clients_test.go
+++ b/server/internal/clients/clients_test.go
@@ -340,7 +340,7 @@ func TestClientReadFixedHeader(t *testing.T) {
 	fh := new(packets.FixedHeader)
 	err := cl.ReadFixedHeader(fh)
 	require.NoError(t, err)
-	require.Equal(t, int64(2), atomic.LoadInt64(&cl.system.BytesRecv))
+	require.Equal(t, int64(2), atomic.LoadInt64(&cl.systemInfo.BytesRecv))
 
 	tail, head := cl.r.GetPos()
 	require.Equal(t, int64(2), tail)
@@ -456,8 +456,8 @@ func TestClientReadOK(t *testing.T) {
 		},
 	})
 
-	require.Equal(t, int64(len(b)), atomic.LoadInt64(&cl.system.BytesRecv))
-	require.Equal(t, int64(2), atomic.LoadInt64(&cl.system.MessagesRecv))
+	require.Equal(t, int64(len(b)), atomic.LoadInt64(&cl.systemInfo.BytesRecv))
+	require.Equal(t, int64(2), atomic.LoadInt64(&cl.systemInfo.MessagesRecv))
 
 }
 
@@ -574,7 +574,7 @@ func TestClientReadPacket(t *testing.T) {
 
 		require.Equal(t, tt.packet, pk, "Mismatched packet: [i:%d] %d", i, tt.bytes[0])
 		if tt.packet.FixedHeader.Type == packets.Publish {
-			require.Equal(t, int64(1), atomic.LoadInt64(&cl.system.PublishRecv))
+			require.Equal(t, int64(1), atomic.LoadInt64(&cl.systemInfo.PublishRecv))
 		}
 	}
 }
@@ -647,10 +647,10 @@ func TestClientWritePacket(t *testing.T) {
 
 		require.Equal(t, tt.bytes, <-o, "Mismatched packet: [i:%d] %d", i, tt.bytes[0])
 		cl.Stop()
-		require.Equal(t, int64(n), atomic.LoadInt64(&cl.system.BytesSent))
-		require.Equal(t, int64(1), atomic.LoadInt64(&cl.system.MessagesSent))
+		require.Equal(t, int64(n), atomic.LoadInt64(&cl.systemInfo.BytesSent))
+		require.Equal(t, int64(1), atomic.LoadInt64(&cl.systemInfo.MessagesSent))
 		if tt.packet.FixedHeader.Type == packets.Publish {
-			require.Equal(t, int64(1), atomic.LoadInt64(&cl.system.PublishSent))
+			require.Equal(t, int64(1), atomic.LoadInt64(&cl.systemInfo.PublishSent))
 		}
 	}
 }

--- a/server/internal/packets/packets.go
+++ b/server/internal/packets/packets.go
@@ -109,6 +109,10 @@ type Packet struct {
 	Topics []string
 	Qoss   []byte
 
+	// If AllowClients set, only deliver to clients in the client allow list.
+	// For use with the OnMessage event hook.
+	AllowClients []string
+
 	ReturnCodes []byte // Suback
 }
 

--- a/server/internal/utils/utils.go
+++ b/server/internal/utils/utils.go
@@ -1,0 +1,14 @@
+package utils
+
+// InSliceString returns true if a string exists in a slice of strings.
+// This temporary and should be replaced with a function from the new
+// go slices package in 1.19 when available.
+// https://github.com/golang/go/issues/45955
+func InSliceString(sl []string, st string) bool {
+	for _, v := range sl {
+		if st == v {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/utils/utils_test.go
+++ b/server/internal/utils/utils_test.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInSliceString(t *testing.T) {
+	sl := []string{"a", "b", "c"}
+	require.Equal(t, true, InSliceString(sl, "b"))
+
+	sl = []string{"a", "a", "a"}
+	require.Equal(t, true, InSliceString(sl, "a"))
+
+	sl = []string{"a", "b", "c"}
+	require.Equal(t, false, InSliceString(sl, "d"))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	Version = "1.0.2" // the server version.
+	Version = "1.0.3" // the server version.
 )
 
 var (

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mochi-co/mqtt/server/internal/clients"
 	"github.com/mochi-co/mqtt/server/internal/packets"
 	"github.com/mochi-co/mqtt/server/internal/topics"
+	"github.com/mochi-co/mqtt/server/internal/utils"
 	"github.com/mochi-co/mqtt/server/listeners"
 	"github.com/mochi-co/mqtt/server/listeners/auth"
 	"github.com/mochi-co/mqtt/server/persistence"
@@ -449,6 +450,14 @@ func (s *Server) retainMessage(pk packets.Packet) {
 func (s *Server) publishToSubscribers(pk packets.Packet) {
 	for id, qos := range s.Topics.Subscribers(pk.TopicName) {
 		if client, ok := s.Clients.Get(id); ok {
+
+			// If the AllowClients value is set, only deliver the packet if the subscribed
+			// client exists in the AllowClients value. For use with the OnMessage event hook
+			// in cases where you want to publish messages to clients selectively.
+			if pk.AllowClients != nil && !utils.InSliceString(pk.AllowClients, id) {
+				continue
+			}
+
 			out := pk.PublishCopy()
 			if qos > out.FixedHeader.Qos { // Inherit higher desired qos values.
 				out.FixedHeader.Qos = qos

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1575,14 +1575,14 @@ func TestServerLoadSubscriptions(t *testing.T) {
 	s.Clients.Add(cl)
 
 	subs := []persistence.Subscription{
-		persistence.Subscription{
+		{
 			ID:     "test:a/b/c",
 			Client: "test",
 			Filter: "a/b/c",
 			QoS:    1,
 			T:      persistence.KSubscription,
 		},
-		persistence.Subscription{
+		{
 			ID:     "test:d/e/f",
 			Client: "test",
 			Filter: "d/e/f",
@@ -1632,7 +1632,7 @@ func TestServerLoadInflight(t *testing.T) {
 	require.NotNil(t, s)
 
 	msgs := []persistence.Message{
-		persistence.Message{
+		{
 			ID:        "client1_if_0",
 			T:         persistence.KInflight,
 			Client:    "client1",
@@ -1642,7 +1642,7 @@ func TestServerLoadInflight(t *testing.T) {
 			Sent:      100,
 			Resends:   0,
 		},
-		persistence.Message{
+		{
 			ID:        "client1_if_100",
 			T:         persistence.KInflight,
 			Client:    "client1",
@@ -1677,7 +1677,7 @@ func TestServerLoadRetained(t *testing.T) {
 	require.NotNil(t, s)
 
 	msgs := []persistence.Message{
-		persistence.Message{
+		{
 			ID: "client1_ret_200",
 			T:  persistence.KRetained,
 			FixedHeader: persistence.FixedHeader{
@@ -1689,7 +1689,7 @@ func TestServerLoadRetained(t *testing.T) {
 			Sent:      100,
 			Resends:   0,
 		},
-		persistence.Message{
+		{
 			ID: "client1_ret_300",
 			T:  persistence.KRetained,
 			FixedHeader: persistence.FixedHeader{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -36,6 +36,15 @@ func setupClient() (s *Server, cl *clients.Client, r net.Conn, w net.Conn) {
 	return
 }
 
+func setupServerClient(s *Server) (cl *clients.Client, r net.Conn, w net.Conn) {
+	r, w = net.Pipe()
+	cl = clients.NewClient(w, circ.NewReader(256, 8), circ.NewWriter(256, 8), s.System)
+	cl.ID = "mochi"
+	cl.AC = new(auth.Allow)
+	cl.Start()
+	return
+}
+
 func TestNew(t *testing.T) {
 	s := New()
 	require.NotNil(t, s)
@@ -558,7 +567,7 @@ func TestServerProcessPublishQoS1Retain(t *testing.T) {
 	cl1.ID = "mochi1"
 	s.Clients.Add(cl1)
 
-	_, cl2, r2, w2 := setupClient()
+	cl2, r2, w2 := setupServerClient(s)
 	cl2.ID = "mochi2"
 	s.Clients.Add(cl2)
 
@@ -687,7 +696,7 @@ func TestServerProcessPublishOfflineQueuing(t *testing.T) {
 	s.Clients.Add(cl1)
 
 	// Start and stop the receiver client
-	_, cl2, _, _ := setupClient()
+	cl2, _, _ := setupServerClient(s)
 	cl2.ID = "mochi2"
 	s.Clients.Add(cl2)
 	s.Topics.Subscribe("qos0", cl2.ID, 0)
@@ -1443,7 +1452,7 @@ func TestServerCloseClientLWT(t *testing.T) {
 	}
 	s.Clients.Add(cl1)
 
-	_, cl2, r2, w2 := setupClient()
+	cl2, r2, w2 := setupServerClient(s)
 	cl2.ID = "mochi2"
 	s.Clients.Add(cl2)
 


### PR DESCRIPTION
Adds a new `AllowClients` field to the packet structure. This field can be set during the `OnMessage` event hook, allowing an embedding server to selectively deliver messages to one or more clients within one or more topics based on their client id. For example:

```
// Add OnMessage Event Hook
server.Events.OnMessage = func(cl events.Client, pk events.Packet) (pkx events.Packet, err error) {
  pkx = pk
    
  // Example of using AllowClients to selectively deliver/drop messages.
  // Only a client with the id of `allowed-client` will received messages on the topic.
  if pkx.TopicName == "a/b/restricted" {
    pkx.AllowClients = []string{"allowed-client"} // slice of known client ids
  }

  return pkx, nil
}
```

If AllowClients is nil or not set, it is ignored and the message is delivered as normal.

All unit tests passing, paho compatibility tests passing