### PR TITLE
OnConnect and OnDisconnect Event Hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cmd/mqtt
 .DS_Store
+server/persistence/bolt/testbolt.db

--- a/examples/events/main.go
+++ b/examples/events/main.go
@@ -44,6 +44,16 @@ func main() {
 		}
 	}()
 
+	// Add OnConnect Event Hook
+	server.Events.OnConnect = func(cl events.Client, pk events.Packet) {
+		fmt.Printf("<< OnConnect client connected %s: %+v\n", cl.ID, pk)
+	}
+
+	// Add OnDisconnect Event Hook
+	server.Events.OnDisconnect = func(cl events.Client, err error) {
+		fmt.Printf("<< OnDisconnect client dicconnected %s: %v\n", cl.ID, err)
+	}
+
 	// Add OnMessage Event Hook
 	server.Events.OnMessage = func(cl events.Client, pk events.Packet) (pkx events.Packet, err error) {
 		pkx = pk

--- a/server/events/events.go
+++ b/server/events/events.go
@@ -7,6 +7,8 @@ import (
 
 type Events struct {
 	OnMessage // published message receieved.
+	OnMessage    // published message receieved.
+	OnConnect    // client connected.
 }
 
 type Packet packets.Packet
@@ -34,3 +36,6 @@ func FromClient(cl *clients.Client) Client {
 // This function will block message dispatching until it returns. To minimise this,
 // have the function open a new goroutine on the embedding side.
 type OnMessage func(Client, Packet) (Packet, error)
+
+// OnConnect is called when a client successfully connects to the broker.
+type OnConnect func(Client, Packet)

--- a/server/events/events.go
+++ b/server/events/events.go
@@ -6,9 +6,9 @@ import (
 )
 
 type Events struct {
-	OnMessage // published message receieved.
 	OnMessage    // published message receieved.
 	OnConnect    // client connected.
+	OnDisconnect // client disconnected.
 }
 
 type Packet packets.Packet
@@ -39,3 +39,8 @@ type OnMessage func(Client, Packet) (Packet, error)
 
 // OnConnect is called when a client successfully connects to the broker.
 type OnConnect func(Client, Packet)
+
+// OnDisconnect is called when a client disconnects to the broker. An error value
+// is passed to the function if the client disconnected abnormally, otherwise it
+// will be nil on a normal disconnect.
+type OnDisconnect func(Client, error)

--- a/server/events/events.go
+++ b/server/events/events.go
@@ -17,7 +17,7 @@ type Client struct {
 }
 
 // FromClient returns an event client from a client.
-func FromClient(cl clients.Client) Client {
+func FromClient(cl *clients.Client) Client {
 	return Client{
 		ID:       cl.ID,
 		Listener: cl.Listener,

--- a/server/server.go
+++ b/server/server.go
@@ -274,6 +274,10 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 	atomic.AddInt64(&s.System.ClientsConnected, -1)
 	atomic.AddInt64(&s.System.ClientsDisconnected, 1)
 
+	if s.Events.OnDisconnect != nil {
+		s.Events.OnDisconnect(events.FromClient(cl), err)
+	}
+
 	return err
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -413,7 +413,7 @@ func (s *Server) processPublish(cl *clients.Client, pk packets.Packet) error {
 
 	// if an OnMessage hook exists, potentially modify the packet.
 	if s.Events.OnMessage != nil {
-		if pkx, err := s.Events.OnMessage(events.FromClient(*cl), events.Packet(pk)); err == nil {
+		if pkx, err := s.Events.OnMessage(events.FromClient(cl), events.Packet(pk)); err == nil {
 			pk = packets.Packet(pkx)
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -259,6 +259,10 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 		})
 	}
 
+	if s.Events.OnConnect != nil {
+		s.Events.OnConnect(events.FromClient(cl), events.Packet(pk))
+	}
+
 	err = cl.Read(s.processPacket)
 	if err != nil {
 		s.closeClient(cl, true)


### PR DESCRIPTION
Adds OnConnect and OnDisconnect Event hooks, allowing embedding services to gain information about the connection and disconnection of clients. 

