### PR TITLE
ARM32 Compatibility

### DIFF
--- a/server/internal/circ/reader.go
+++ b/server/internal/circ/reader.go
@@ -32,10 +32,10 @@ func NewReaderFromSlice(block int, p []byte) *Reader {
 // ReadFrom reads bytes from an io.Reader and commits them to the buffer when
 // there is sufficient capacity to do so.
 func (b *Reader) ReadFrom(r io.Reader) (total int64, err error) {
-	atomic.StoreInt64(&b.State, 1)
-	defer atomic.StoreInt64(&b.State, 0)
+	atomic.StoreUint32(&b.State, 1)
+	defer atomic.StoreUint32(&b.State, 0)
 	for {
-		if atomic.LoadInt64(&b.done) == 1 {
+		if atomic.LoadUint32(&b.done) == 1 {
 			return total, nil
 		}
 

--- a/server/internal/circ/reader_test.go
+++ b/server/internal/circ/reader_test.go
@@ -60,7 +60,7 @@ func TestReadFromWrap(t *testing.T) {
 	}()
 	time.Sleep(time.Millisecond * 100)
 	go func() {
-		atomic.StoreInt64(&buf.done, 1)
+		atomic.StoreUint32(&buf.done, 1)
 		buf.rcond.L.Lock()
 		buf.rcond.Broadcast()
 		buf.rcond.L.Unlock()
@@ -116,7 +116,7 @@ func TestReadEnded(t *testing.T) {
 		o <- err
 	}()
 	time.Sleep(time.Millisecond)
-	atomic.StoreInt64(&buf.done, 1)
+	atomic.StoreUint32(&buf.done, 1)
 	buf.wcond.L.Lock()
 	buf.wcond.Broadcast()
 	buf.wcond.L.Unlock()

--- a/server/internal/circ/writer.go
+++ b/server/internal/circ/writer.go
@@ -32,10 +32,10 @@ func NewWriterFromSlice(block int, p []byte) *Writer {
 
 // WriteTo writes the contents of the buffer to an io.Writer.
 func (b *Writer) WriteTo(w io.Writer) (total int, err error) {
-	atomic.StoreInt64(&b.State, 2)
-	defer atomic.StoreInt64(&b.State, 0)
+	atomic.StoreUint32(&b.State, 2)
+	defer atomic.StoreUint32(&b.State, 0)
 	for {
-		if atomic.LoadInt64(&b.done) == 1 && b.CapDelta() == 0 {
+		if atomic.LoadUint32(&b.done) == 1 && b.CapDelta() == 0 {
 			return total, io.EOF
 		}
 

--- a/server/internal/circ/writer_test.go
+++ b/server/internal/circ/writer_test.go
@@ -59,7 +59,7 @@ func TestWriteTo(t *testing.T) {
 		}()
 
 		time.Sleep(time.Millisecond * 100)
-		atomic.StoreInt64(&buf.done, 1)
+		atomic.StoreUint32(&buf.done, 1)
 		buf.wcond.L.Lock()
 		buf.wcond.Broadcast()
 		buf.wcond.L.Unlock()

--- a/server/internal/clients/clients_test.go
+++ b/server/internal/clients/clients_test.go
@@ -316,8 +316,8 @@ func TestClientStart(t *testing.T) {
 	cl.Start()
 	defer cl.Stop()
 	time.Sleep(time.Millisecond)
-	require.Equal(t, int64(1), atomic.LoadInt64(&cl.r.State))
-	require.Equal(t, int64(2), atomic.LoadInt64(&cl.w.State))
+	require.Equal(t, uint32(1), atomic.LoadUint32(&cl.r.State))
+	require.Equal(t, uint32(2), atomic.LoadUint32(&cl.w.State))
 }
 
 func BenchmarkClientStart(b *testing.B) {

--- a/server/internal/packets/fixedheader.go
+++ b/server/internal/packets/fixedheader.go
@@ -16,7 +16,7 @@ type FixedHeader struct {
 // Encode encodes the FixedHeader and returns a bytes buffer.
 func (fh *FixedHeader) Encode(buf *bytes.Buffer) {
 	buf.WriteByte(fh.Type<<4 | encodeBool(fh.Dup)<<3 | fh.Qos<<1 | encodeBool(fh.Retain))
-	encodeLength(buf, fh.Remaining)
+	encodeLength(buf, int64(fh.Remaining))
 }
 
 // decode extracts the specification bits from the header byte.
@@ -44,7 +44,7 @@ func (fh *FixedHeader) Decode(headerByte byte) error {
 }
 
 // encodeLength writes length bits for the header.
-func encodeLength(buf *bytes.Buffer, length int) {
+func encodeLength(buf *bytes.Buffer, length int64) {
 	for {
 		digit := byte(length % 128)
 		length /= 128

--- a/server/internal/packets/fixedheader_test.go
+++ b/server/internal/packets/fixedheader_test.go
@@ -192,7 +192,7 @@ func BenchmarkFixedHeaderDecode(b *testing.B) {
 
 func TestEncodeLength(t *testing.T) {
 	tt := []struct {
-		have int
+		have int64
 		want []byte
 	}{
 		{

--- a/server/listeners/http_sysinfo.go
+++ b/server/listeners/http_sysinfo.go
@@ -22,7 +22,7 @@ type HTTPStats struct {
 	system  *system.Info // pointers to the server data.
 	address string       // the network address to bind to.
 	listen  *http.Server // the http server.
-	end     int64        // ensure the close methods are only called once.}
+	end     uint32       // ensure the close methods are only called once.}
 }
 
 // NewHTTPStats initialises and returns a new HTTP listener, listening on an address.
@@ -98,9 +98,7 @@ func (l *HTTPStats) Close(closeClients CloseFunc) {
 	l.Lock()
 	defer l.Unlock()
 
-	if atomic.LoadInt64(&l.end) == 0 {
-		atomic.StoreInt64(&l.end, 1)
-
+	if atomic.CompareAndSwapUint32(&l.end, 0, 1) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		l.listen.Shutdown(ctx)

--- a/server/listeners/websocket.go
+++ b/server/listeners/websocket.go
@@ -34,7 +34,7 @@ type Websocket struct {
 	config    *Config       // configuration values for the listener.
 	address   string        // the network address to bind to.
 	listen    *http.Server  // an http server for serving websocket connections.
-	end       int64         // ensure the close methods are only called once.
+	end       uint32        // ensure the close methods are only called once.
 	establish EstablishFunc // the server's establish conection handler.
 }
 
@@ -162,8 +162,7 @@ func (l *Websocket) Close(closeClients CloseFunc) {
 	l.Lock()
 	defer l.Unlock()
 
-	if atomic.LoadInt64(&l.end) == 0 {
-		atomic.StoreInt64(&l.end, 1)
+	if atomic.CompareAndSwapUint32(&l.end, 0, 1) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		l.listen.Shutdown(ctx)

--- a/server/server.go
+++ b/server/server.go
@@ -208,7 +208,7 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 	var sessionPresent bool
 	if existing, ok := s.Clients.Get(pk.ClientIdentifier); ok {
 		existing.Lock()
-		if atomic.LoadInt64(&existing.State.Done) == 1 {
+		if atomic.LoadUint32(&existing.State.Done) == 1 {
 			atomic.AddInt64(&s.System.ClientsDisconnected, -1)
 		}
 		existing.Stop()

--- a/server/system/system_test.go
+++ b/server/system/system_test.go
@@ -1,0 +1,21 @@
+package system
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoAlignment(t *testing.T) {
+	typ := reflect.TypeOf(Info{})
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		switch f.Type.Kind() {
+		case reflect.Int64, reflect.Uint64:
+			require.Equalf(t, uintptr(0), f.Offset%8,
+				"%s requires 64-bit alignment for atomic: offset %d",
+				f.Name, f.Offset)
+		}
+	}
+}


### PR DESCRIPTION
Issue #17 demonstrated that the broker could not be run on ARM32 due to invalid memory address errors. This is due to the use of unaligned int64s. This PR corrects the alignment of structs using atomic int64s. Additionally, where it makes sense to do so, int64 fields have been converted to uint32 fields.

- Passes Paho interoperability tests
- Passes all unit tests