### PR TITLE
Optimise Struct Fields + Fixes

### DIFF
--- a/server/internal/circ/buffer.go
+++ b/server/internal/circ/buffer.go
@@ -15,27 +15,25 @@ var (
 	ErrInsufficientBytes = errors.New("Insufficient bytes to return")
 )
 
-// buffer contains core values and methods to be included in a reader or writer.
 type Buffer struct {
-	Mu    sync.RWMutex // the buffer needs it's own mutex to work properly.
-	ID    string       // the identifier of the buffer. This is used in debug output.
-	size  int          // the size of the buffer.
-	mask  int          // a bitmask of the buffer size (size-1).
-	block int          // the size of the R/W block.
 	buf   []byte       // the bytes buffer.
 	tmp   []byte       // a temporary buffer.
-	_     int32        // align the next fields to an 8-byte boundary for atomic access.
+	Mu    sync.RWMutex // the buffer needs its own mutex to work properly.
+	ID    string       // the identifier of the buffer. This is used in debug output.
 	head  int64        // the current position in the sequence - a forever increasing index.
 	tail  int64        // the committed position in the sequence - a forever increasing index.
 	rcond *sync.Cond   // the sync condition for the buffer reader.
 	wcond *sync.Cond   // the sync condition for the buffer writer.
+	size  int          // the size of the buffer.
+	mask  int          // a bitmask of the buffer size (size-1).
+	block int          // the size of the R/W block.
 	done  uint32       // indicates that the buffer is closed.
 	State uint32       // indicates whether the buffer is reading from (1) or writing to (2).
 }
 
 // NewBuffer returns a new instance of buffer. You should call NewReader or
 // NewWriter instead of this function.
-func NewBuffer(size, block int) Buffer {
+func NewBuffer(size, block int) *Buffer {
 	if size == 0 {
 		size = DefaultBufferSize
 	}

--- a/server/internal/circ/buffer.go
+++ b/server/internal/circ/buffer.go
@@ -46,7 +46,7 @@ func NewBuffer(size, block int) *Buffer {
 		size = 2 * block
 	}
 
-	return Buffer{
+	return &Buffer{
 		size:  size,
 		mask:  size - 1,
 		block: block,
@@ -58,14 +58,14 @@ func NewBuffer(size, block int) *Buffer {
 
 // NewBufferFromSlice returns a new instance of buffer using a
 // pre-existing byte slice.
-func NewBufferFromSlice(block int, buf []byte) Buffer {
+func NewBufferFromSlice(block int, buf []byte) *Buffer {
 	l := len(buf)
 
 	if block == 0 {
 		block = DefaultBlockSize
 	}
 
-	b := Buffer{
+	b := &Buffer{
 		size:  l,
 		mask:  l - 1,
 		block: block,

--- a/server/internal/circ/pool.go
+++ b/server/internal/circ/pool.go
@@ -6,13 +6,13 @@ import (
 
 // BytesPool is a pool of []byte.
 type BytesPool struct {
-	pool sync.Pool
+	pool *sync.Pool
 }
 
 // NewBytesPool returns a sync.pool of []byte.
-func NewBytesPool(n int) BytesPool {
-	return BytesPool{
-		pool: sync.Pool{
+func NewBytesPool(n int) *BytesPool {
+	return &BytesPool{
+		pool: &sync.Pool{
 			New: func() interface{} {
 				return make([]byte, n)
 			},

--- a/server/internal/circ/pool_test.go
+++ b/server/internal/circ/pool_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestNewBytesPool(t *testing.T) {
 	bpool := NewBytesPool(256)
-	require.NotNil(t, &bpool.pool)
+	require.NotNil(t, bpool.pool)
 }
 
 func BenchmarkNewBytesPool(b *testing.B) {

--- a/server/internal/circ/pool_test.go
+++ b/server/internal/circ/pool_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestNewBytesPool(t *testing.T) {
 	bpool := NewBytesPool(256)
-	require.NotNil(t, bpool.pool)
+	require.NotNil(t, &bpool.pool)
 }
 
 func BenchmarkNewBytesPool(b *testing.B) {

--- a/server/internal/circ/reader.go
+++ b/server/internal/circ/reader.go
@@ -7,7 +7,7 @@ import (
 
 // Reader is a circular buffer for reading data from an io.Reader.
 type Reader struct {
-	Buffer
+	*Buffer
 }
 
 // NewReader returns a new Circular Reader.

--- a/server/internal/circ/writer_test.go
+++ b/server/internal/circ/writer_test.go
@@ -52,7 +52,7 @@ func TestWriteTo(t *testing.T) {
 		var b bytes.Buffer
 		w := bufio.NewWriter(&b)
 
-		nc := make(chan int)
+		nc := make(chan int64)
 		go func() {
 			n, _ := buf.WriteTo(w)
 			nc <- n

--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -119,7 +119,7 @@ func NewClient(c net.Conn, r *circ.Reader, w *circ.Writer, s *system.Info) *Clie
 		w:          w,
 		systemInfo: s,
 		keepalive:  defaultKeepalive,
-		Inflight: Inflight{
+		Inflight: &Inflight{
 			internal: make(map[uint16]InflightMessage),
 		},
 		Subscriptions: make(map[string]byte),
@@ -139,7 +139,7 @@ func NewClient(c net.Conn, r *circ.Reader, w *circ.Writer, s *system.Info) *Clie
 // method is typically called by the persistence restoration system.
 func NewClientStub(s *system.Info) *Client {
 	return &Client{
-		Inflight: Inflight{
+		Inflight: &Inflight{
 			internal: make(map[uint16]InflightMessage),
 		},
 		Subscriptions: make(map[string]byte),

--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -84,30 +84,30 @@ func (cl *Clients) GetByListener(id string) []*Client {
 
 // Client contains information about a client known by the broker.
 type Client struct {
-	sync.RWMutex
+	State         State                // the operational state of the client.
+	LWT           LWT                  // the last will and testament for the client.
+	Inflight      *Inflight            // a map of in-flight qos messages.
+	sync.RWMutex                       // mutex
+	Username      []byte               // the username the client authenticated with.
+	AC            auth.Controller      // an auth controller inherited from the listener.
+	Listener      string               // the id of the listener the client is connected to.
+	ID            string               // the client id.
 	conn          net.Conn             // the net.Conn used to establish the connection.
 	r             *circ.Reader         // a reader for reading incoming bytes.
 	w             *circ.Writer         // a writer for writing outgoing bytes.
-	ID            string               // the client id.
-	AC            auth.Controller      // an auth controller inherited from the listener.
 	Subscriptions topics.Subscriptions // a map of the subscription filters a client maintains.
-	Listener      string               // the id of the listener the client is connected to.
-	Inflight      Inflight             // a map of in-flight qos messages.
-	Username      []byte               // the username the client authenticated with.
+	systemInfo    *system.Info         // pointers to server system info.
+	packetID      uint32               // the current highest packetID.
 	keepalive     uint16               // the number of seconds the connection can wait.
 	cleanSession  bool                 // indicates if the client expects a clean-session.
-	packetID      uint32               // the current highest packetID.
-	LWT           LWT                  // the last will and testament for the client.
-	State         State                // the operational state of the client.
-	systemInfo    *system.Info         // pointers to server system info.
 }
 
 // State tracks the state of the client.
 type State struct {
-	Done    uint32          // atomic counter which indicates that the client has closed.
 	started *sync.WaitGroup // tracks the goroutines which have been started.
 	endedW  *sync.WaitGroup // tracks when the writer has ended.
 	endedR  *sync.WaitGroup // tracks when the reader has ended.
+	Done    uint32          // atomic counter which indicates that the client has closed.
 	endOnce sync.Once       // only end once.
 }
 
@@ -454,8 +454,8 @@ func (cl *Client) WritePacket(pk packets.Packet) (n int, err error) {
 
 // LWT contains the last will and testament details for a client connection.
 type LWT struct {
-	Topic   string // the topic the will message shall be sent to.
 	Message []byte // the message that shall be sent when the client disconnects.
+	Topic   string // the topic the will message shall be sent to.
 	Qos     byte   // the quality of service desired.
 	Retain  bool   // indicates whether the will message should be retained
 }

--- a/server/internal/packets/fixedheader.go
+++ b/server/internal/packets/fixedheader.go
@@ -6,11 +6,11 @@ import (
 
 // FixedHeader contains the values of the fixed header portion of the MQTT packet.
 type FixedHeader struct {
-	Type      byte // the type of the packet (PUBLISH, SUBSCRIBE, etc) from bits 7 - 4 (byte 1).
-	Dup       bool // indicates if the packet was already sent at an earlier time.
-	Qos       byte // indicates the quality of service expected.
-	Retain    bool // whether the message should be retained.
 	Remaining int  // the number of remaining bytes in the payload.
+	Type      byte // the type of the packet (PUBLISH, SUBSCRIBE, etc) from bits 7 - 4 (byte 1).
+	Qos       byte // indicates the quality of service expected.
+	Dup       bool // indicates if the packet was already sent at an earlier time.
+	Retain    bool // whether the message should be retained.
 }
 
 // Encode encodes the FixedHeader and returns a bytes buffer.

--- a/server/internal/packets/fixedheader_test.go
+++ b/server/internal/packets/fixedheader_test.go
@@ -18,130 +18,130 @@ type fixedHeaderTable struct {
 var fixedHeaderExpected = []fixedHeaderTable{
 	{
 		rawBytes: []byte{Connect << 4, 0x00},
-		header:   FixedHeader{Connect, false, 0, false, 0}, // Type byte, Dup bool, Qos byte, Retain bool, Remaining int
+		header:   FixedHeader{Type: Connect, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Connack << 4, 0x00},
-		header:   FixedHeader{Connack, false, 0, false, 0},
+		header:   FixedHeader{Type: Connack, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish << 4, 0x00},
-		header:   FixedHeader{Publish, false, 0, false, 0},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish<<4 | 1<<1, 0x00},
-		header:   FixedHeader{Publish, false, 1, false, 0},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 1, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish<<4 | 1<<1 | 1, 0x00},
-		header:   FixedHeader{Publish, false, 1, true, 0},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 1, Retain: true, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish<<4 | 2<<1, 0x00},
-		header:   FixedHeader{Publish, false, 2, false, 0},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 2, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish<<4 | 2<<1 | 1, 0x00},
-		header:   FixedHeader{Publish, false, 2, true, 0},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 2, Retain: true, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish<<4 | 1<<3, 0x00},
-		header:   FixedHeader{Publish, true, 0, false, 0},
+		header:   FixedHeader{Type: Publish, Dup: true, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish<<4 | 1<<3 | 1, 0x00},
-		header:   FixedHeader{Publish, true, 0, true, 0},
+		header:   FixedHeader{Type: Publish, Dup: true, Qos: 0, Retain: true, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish<<4 | 1<<3 | 1<<1 | 1, 0x00},
-		header:   FixedHeader{Publish, true, 1, true, 0},
+		header:   FixedHeader{Type: Publish, Dup: true, Qos: 1, Retain: true, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Publish<<4 | 1<<3 | 2<<1 | 1, 0x00},
-		header:   FixedHeader{Publish, true, 2, true, 0},
+		header:   FixedHeader{Type: Publish, Dup: true, Qos: 2, Retain: true, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Puback << 4, 0x00},
-		header:   FixedHeader{Puback, false, 0, false, 0},
+		header:   FixedHeader{Type: Puback, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Pubrec << 4, 0x00},
-		header:   FixedHeader{Pubrec, false, 0, false, 0},
+		header:   FixedHeader{Type: Pubrec, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Pubrel<<4 | 1<<1, 0x00},
-		header:   FixedHeader{Pubrel, false, 1, false, 0},
+		header:   FixedHeader{Type: Pubrel, Dup: false, Qos: 1, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Pubcomp << 4, 0x00},
-		header:   FixedHeader{Pubcomp, false, 0, false, 0},
+		header:   FixedHeader{Type: Pubcomp, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Subscribe<<4 | 1<<1, 0x00},
-		header:   FixedHeader{Subscribe, false, 1, false, 0},
+		header:   FixedHeader{Type: Subscribe, Dup: false, Qos: 1, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Suback << 4, 0x00},
-		header:   FixedHeader{Suback, false, 0, false, 0},
+		header:   FixedHeader{Type: Suback, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Unsubscribe<<4 | 1<<1, 0x00},
-		header:   FixedHeader{Unsubscribe, false, 1, false, 0},
+		header:   FixedHeader{Type: Unsubscribe, Dup: false, Qos: 1, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Unsuback << 4, 0x00},
-		header:   FixedHeader{Unsuback, false, 0, false, 0},
+		header:   FixedHeader{Type: Unsuback, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Pingreq << 4, 0x00},
-		header:   FixedHeader{Pingreq, false, 0, false, 0},
+		header:   FixedHeader{Type: Pingreq, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Pingresp << 4, 0x00},
-		header:   FixedHeader{Pingresp, false, 0, false, 0},
+		header:   FixedHeader{Type: Pingresp, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 	{
 		rawBytes: []byte{Disconnect << 4, 0x00},
-		header:   FixedHeader{Disconnect, false, 0, false, 0},
+		header:   FixedHeader{Type: Disconnect, Dup: false, Qos: 0, Retain: false, Remaining: 0},
 	},
 
 	// remaining length
 	{
 		rawBytes: []byte{Publish << 4, 0x0a},
-		header:   FixedHeader{Publish, false, 0, false, 10},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 0, Retain: false, Remaining: 10},
 	},
 	{
 		rawBytes: []byte{Publish << 4, 0x80, 0x04},
-		header:   FixedHeader{Publish, false, 0, false, 512},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 0, Retain: false, Remaining: 512},
 	},
 	{
 		rawBytes: []byte{Publish << 4, 0xd2, 0x07},
-		header:   FixedHeader{Publish, false, 0, false, 978},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 0, Retain: false, Remaining: 978},
 	},
 	{
 		rawBytes: []byte{Publish << 4, 0x86, 0x9d, 0x01},
-		header:   FixedHeader{Publish, false, 0, false, 20102},
+		header:   FixedHeader{Type: Publish, Dup: false, Qos: 0, Retain: false, Remaining: 20102},
 	},
 	{
 		rawBytes:    []byte{Publish << 4, 0xd5, 0x86, 0xf9, 0x9e, 0x01},
-		header:      FixedHeader{Publish, false, 0, false, 333333333},
+		header:      FixedHeader{Type: Publish, Dup: false, Qos: 0, Retain: false, Remaining: 333333333},
 		packetError: true,
 	},
 
 	// Invalid flags for packet
 	{
 		rawBytes:  []byte{Connect<<4 | 1<<3, 0x00},
-		header:    FixedHeader{Connect, true, 0, false, 0},
+		header:    FixedHeader{Type: Connect, Dup: true, Qos: 0, Retain: false, Remaining: 0},
 		flagError: true,
 	},
 	{
 		rawBytes:  []byte{Connect<<4 | 1<<1, 0x00},
-		header:    FixedHeader{Connect, false, 1, false, 0},
+		header:    FixedHeader{Type: Connect, Dup: false, Qos: 1, Retain: false, Remaining: 0},
 		flagError: true,
 	},
 	{
 		rawBytes:  []byte{Connect<<4 | 1, 0x00},
-		header:    FixedHeader{Connect, false, 0, true, 0},
+		header:    FixedHeader{Type: Connect, Dup: false, Qos: 0, Retain: true, Remaining: 0},
 		flagError: true,
 	},
 }

--- a/server/internal/packets/packets.go
+++ b/server/internal/packets/packets.go
@@ -76,44 +76,31 @@ var (
 // packet structs, this is a single concrete packet type to cover all packet
 // types, which allows us to take advantage of various compiler optimizations.
 type Packet struct {
-	FixedHeader FixedHeader
-
-	PacketID uint16
-
-	// Connect
+	FixedHeader      FixedHeader
+	AllowClients     []string // For use with OnMessage event hook.
+	Topics           []string
+	ReturnCodes      []byte
 	ProtocolName     []byte
+	Qoss             []byte
+	Payload          []byte
+	Username         []byte
+	Password         []byte
+	WillMessage      []byte
+	ClientIdentifier string
+	TopicName        string
+	WillTopic        string
+	PacketID         uint16
+	Keepalive        uint16
+	ReturnCode       byte
 	ProtocolVersion  byte
+	WillQos          byte
+	ReservedBit      byte
 	CleanSession     bool
 	WillFlag         bool
-	WillQos          byte
 	WillRetain       bool
 	UsernameFlag     bool
 	PasswordFlag     bool
-	ReservedBit      byte
-	Keepalive        uint16
-	ClientIdentifier string
-	WillTopic        string
-	WillMessage      []byte
-	Username         []byte
-	Password         []byte
-
-	// Connack
-	SessionPresent bool
-	ReturnCode     byte
-
-	// Publish
-	TopicName string
-	Payload   []byte
-
-	// Subscribe, Unsubscribe
-	Topics []string
-	Qoss   []byte
-
-	// If AllowClients set, only deliver to clients in the client allow list.
-	// For use with the OnMessage event hook.
-	AllowClients []string
-
-	ReturnCodes []byte // Suback
+	SessionPresent   bool
 }
 
 // ConnectEncode encodes a connect packet.

--- a/server/internal/topics/trie.go
+++ b/server/internal/topics/trie.go
@@ -175,12 +175,12 @@ func (x *Index) Messages(filter string) []packets.Packet {
 
 // Leaf is a child node on the tree.
 type Leaf struct {
+	Message packets.Packet   // a message which has been retained for a specific topic.
 	Key     string           // the key that was used to create the leaf.
+	Filter  string           // the path of the topic filter being matched.
 	Parent  *Leaf            // a pointer to the parent node for the leaf.
 	Leaves  map[string]*Leaf // a map of child nodes, keyed on particle id.
 	Clients map[string]byte  // a map of client ids subscribed to the topic.
-	Filter  string           // the path of the topic filter being matched.
-	Message packets.Packet   // a message which has been retained for a specific topic.
 }
 
 // scanSubscribers recursively steps through a branch of leaves finding clients who

--- a/server/listeners/http_sysinfo.go
+++ b/server/listeners/http_sysinfo.go
@@ -18,9 +18,9 @@ import (
 type HTTPStats struct {
 	sync.RWMutex
 	id      string       // the internal id of the listener.
+	address string       // the network address to bind to.
 	config  *Config      // configuration values for the listener.
 	system  *system.Info // pointers to the server data.
-	address string       // the network address to bind to.
 	listen  *http.Server // the http server.
 	end     uint32       // ensure the close methods are only called once.}
 }

--- a/server/listeners/listeners.go
+++ b/server/listeners/listeners.go
@@ -38,10 +38,10 @@ type Listener interface {
 
 // Listeners contains the network listeners for the broker.
 type Listeners struct {
-	sync.RWMutex
 	wg       sync.WaitGroup      // a waitgroup that waits for all listeners to finish.
 	internal map[string]Listener // a map of active listeners.
 	system   *system.Info        // pointers to system info.
+	sync.RWMutex
 }
 
 // New returns a new instance of Listeners.

--- a/server/listeners/mock.go
+++ b/server/listeners/mock.go
@@ -22,11 +22,11 @@ func MockEstablisher(id string, c net.Conn, ac auth.Controller) error {
 type MockListener struct {
 	sync.RWMutex
 	id        string    // the id of the listener.
-	Config    *Config   // configuration for the listener.
 	address   string    // the network address the listener binds to.
-	Listening bool      // indiciate the listener is listening.
-	Serving   bool      // indicate the listener is serving.
+	Config    *Config   // configuration for the listener.
 	done      chan bool // indicate the listener is done.
+	Serving   bool      // indicate the listener is serving.
+	Listening bool      // indiciate the listener is listening.
 	ErrListen bool      // throw an error on listen.
 }
 

--- a/server/listeners/tcp.go
+++ b/server/listeners/tcp.go
@@ -14,10 +14,10 @@ import (
 type TCP struct {
 	sync.RWMutex
 	id       string       // the internal id of the listener.
-	config   *Config      // configuration values for the listener.
 	protocol string       // the TCP protocol to use.
 	address  string       // the network address to bind to.
 	listen   net.Listener // a net.Listener which will listen for new clients.
+	config   *Config      // configuration values for the listener.
 	end      uint32       // ensure the close methods are only called once.
 }
 

--- a/server/listeners/websocket.go
+++ b/server/listeners/websocket.go
@@ -31,11 +31,11 @@ var (
 type Websocket struct {
 	sync.RWMutex
 	id        string        // the internal id of the listener.
-	config    *Config       // configuration values for the listener.
 	address   string        // the network address to bind to.
+	config    *Config       // configuration values for the listener.
 	listen    *http.Server  // an http server for serving websocket connections.
-	end       uint32        // ensure the close methods are only called once.
 	establish EstablishFunc // the server's establish conection handler.
+	end       uint32        // ensure the close methods are only called once.
 }
 
 // wsConn is a websocket connection which satisfies the net.Conn interface.

--- a/server/persistence/persistence.go
+++ b/server/persistence/persistence.go
@@ -53,50 +53,50 @@ type Subscription struct {
 
 // Message contains the details of a retained or inflight message.
 type Message struct {
-	ID          string      // the storage key.
-	T           string      // the type of the stored data.
-	Client      string      // the id of the client who sent the message (if inflight).
-	FixedHeader FixedHeader // the header properties of the message.
-	PacketID    uint16      // the unique id of the packet (if inflight).
-	TopicName   string      // the topic the message was sent to (if retained).
 	Payload     []byte      // the message payload (if retained).
+	FixedHeader FixedHeader // the header properties of the message.
+	T           string      // the type of the stored data.
+	ID          string      // the storage key.
+	Client      string      // the id of the client who sent the message (if inflight).
+	TopicName   string      // the topic the message was sent to (if retained).
 	Sent        int64       // the last time the message was sent (for retries) in unixtime (if inflight).
 	Resends     int         // the number of times the message was attempted to be sent (if inflight).
+	PacketID    uint16      // the unique id of the packet (if inflight).
 }
 
 // FixedHeader contains the fixed header properties of a message.
 type FixedHeader struct {
-	Type      byte // the type of the packet (PUBLISH, SUBSCRIBE, etc) from bits 7 - 4 (byte 1).
-	Dup       bool // indicates if the packet was already sent at an earlier time.
-	Qos       byte // indicates the quality of service expected.
-	Retain    bool // whether the message should be retained.
 	Remaining int  // the number of remaining bytes in the payload.
+	Type      byte // the type of the packet (PUBLISH, SUBSCRIBE, etc) from bits 7 - 4 (byte 1).
+	Qos       byte // indicates the quality of service expected.
+	Dup       bool // indicates if the packet was already sent at an earlier time.
+	Retain    bool // whether the message should be retained.
 }
 
 // Client contains client data that can be persistently stored.
 type Client struct {
+	LWT      LWT    // the last-will-and-testament message for the client.
+	Username []byte // the username the client authenticated with.
 	ID       string // the storage key.
 	ClientID string // the id of the client.
 	T        string // the type of the stored data.
 	Listener string // the last known listener id for the client
-	Username []byte // the username the client authenticated with.
-	LWT      LWT    // the last-will-and-testament message for the client.
 }
 
 // LWT contains details about a clients LWT payload.
 type LWT struct {
-	Topic   string // the topic the will message shall be sent to.
 	Message []byte // the message that shall be sent when the client disconnects.
+	Topic   string // the topic the will message shall be sent to.
 	Qos     byte   // the quality of service desired.
 	Retain  bool   // indicates whether the will message should be retained
 }
 
 // MockStore is a mock storage backend for testing.
 type MockStore struct {
+	Fail     map[string]bool // issue errors for different methods.
 	FailOpen bool            // error on open.
 	Closed   bool            // indicate mock store is closed.
 	Opened   bool            // indicate mock store is open.
-	Fail     map[string]bool // issue errors for different methods.
 }
 
 // Open opens the storage instance.

--- a/server/server.go
+++ b/server/server.go
@@ -221,7 +221,7 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 				}
 			}
 		} else {
-			cl.Inflight = existing.Inflight // Inherit from existing session.
+			cl.Inflight = existing.Inflight // Take address of existing session.
 			cl.Subscriptions = existing.Subscriptions
 			sessionPresent = true
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -45,16 +45,16 @@ var (
 // Server is an MQTT broker server. It should be created with server.New()
 // in order to ensure all the internal fields are correctly populated.
 type Server struct {
+	inline    inlineMessages       // channels for direct publishing.
+	Events    events.Events        // overrideable event hooks.
+	Store     persistence.Store    // a persistent storage backend if desired.
 	Listeners *listeners.Listeners // listeners are network interfaces which listen for new connections.
 	Clients   *clients.Clients     // clients which are known to the broker.
 	Topics    *topics.Index        // an index of topic filter subscriptions and retained messages.
 	System    *system.Info         // values about the server commonly found in $SYS topics.
-	Store     persistence.Store    // a persistent storage backend if desired.
-	done      chan bool            // indicate that the server is ending.
-	bytepool  circ.BytesPool       // a byte pool for incoming and outgoing packets.
+	bytepool  *circ.BytesPool      // a byte pool for incoming and outgoing packets.
 	sysTicker *time.Ticker         // the interval ticker for sending updating $SYS topics.
-	inline    inlineMessages       // channels for direct publishing.
-	Events    events.Events        // overrideable event hooks.
+	done      chan bool            // indicate that the server is ending.
 }
 
 // inlineMessages contains channels for handling inline (direct) publishing.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -416,7 +416,7 @@ func TestServerEventOnDisconnectOnError(t *testing.T) {
 	errx := <-o
 	require.Error(t, errx)
 	require.Equal(t, "No valid packet available; 0", errx.Error())
-	fmt.Println(hookedErr)
+
 	require.Equal(t, errx, hookedErr)
 
 	require.Equal(t, events.Client{


### PR DESCRIPTION
In v1.1.0 we made changes to the alignment of several structs (particularly `Buffer`) in order to ensure the broker is compatible with 32bit systems. In the process we discovered that other structs were not aligned in an optimised manner. This PR aligns all structs to 8bit boundaries and ensures they are packed most efficiently.

This PR also contains other minor fixes:
- Locks were being copied in the `Inflight`, `Buffer` structs. These are now passed by address where appropriate.
- The method signature for `writer WriteTo` implemented an `int` instead of `int64`. This has been corrected and references to the method updated.
- Small changes to comments for clarity.

Tested on 32 and 64 bit platforms:
- Paho interoperability tests pass.
- Multiple iterations of inovex mqtt-stresser succeed without issue.
- All unit tests pass.

@rkennedy I would be very grateful if you could give this a quick look over when you have a chance and test on your ARM device before I merge it. 
