### PR TITLE
Support non-UTF8 payloads (per MQTT specification)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ MQTT stands for MQ Telemetry Transport. It is a publish/subscribe, extremely sim
 - Ring Buffer packet codec.
 - TCP, Websocket, (including SSL/TLS) and Dashboard listeners.
 - Interfaces for Client Authentication and Topic access control.
-- Redis and Bolt persistence and storage interfaces (see examples folder).
+- Bolt persistence and storage interfaces (see examples folder).
 - Directly Publishing from embedding service (`s.Publish(topic, message, retain)`).
 - Basic Event Hooks (currently `OnMessage`, `OnConnect`, `OnDisconnect`).
 - ARM32 Compatible.

--- a/server/internal/packets/codec.go
+++ b/server/internal/packets/codec.go
@@ -28,6 +28,10 @@ func decodeString(buf []byte, offset int) (string, int, error) {
 		return "", 0, err
 	}
 
+	if !validUTF8(b) {
+		return "", 0, ErrOffsetStrInvalidUTF8
+	}
+
 	return bytesToString(b), n, nil
 }
 
@@ -39,12 +43,10 @@ func decodeBytes(buf []byte, offset int) ([]byte, int, error) {
 	}
 
 	if next+int(length) > len(buf) {
-		return make([]byte, 0, 0), 0, ErrOffsetStrOutOfRange
+		return make([]byte, 0, 0), 0, ErrOffsetBytesOutOfRange
 	}
 
-	if !validUTF8(buf[next : next+int(length)]) {
-		return make([]byte, 0, 0), 0, ErrOffsetStrInvalidUTF8
-	}
+	// Note: there is no validUTF8() test for []byte payloads
 
 	return buf[next : next+int(length)], next + int(length), nil
 }

--- a/server/internal/packets/packets.go
+++ b/server/internal/packets/packets.go
@@ -60,7 +60,6 @@ var (
 
 	// PACKETS
 	ErrProtocolViolation        = errors.New("protocol violation")
-	ErrOffsetStrOutOfRange      = errors.New("offset string out of range")
 	ErrOffsetBytesOutOfRange    = errors.New("offset bytes out of range")
 	ErrOffsetByteOutOfRange     = errors.New("offset byte out of range")
 	ErrOffsetBoolOutOfRange     = errors.New("offset bool out of range")

--- a/server/server.go
+++ b/server/server.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	Version = "1.1.2" // the server version.
+	Version = "1.1.1" // the server version.
 )
 
 var (


### PR DESCRIPTION
**What are you trying to achieve?**

I'm testing this MQTT broker service with the use of Sparkplug-B payloads. The payloads are Google protobuf encoded, are not and should not be expected to be valid UTF8. The is-valid-UTF8 test was causing my device's connection to fail during setup because the Will Message was invalid protobuf data.

The MQTT specification does not require UTF8 for []byte payloads, only for certain string fields, as I understand it.

Note: While testing, I discovered that ErrOffsetBytesOutOfRange was not being used. The `decodeBytes()` method was returning the error for string decoding. I have updated/improved the tests of the decode methods to test for expected errors explicitly and added an invalid-UTF8 test case.

**Why are you doing this?**

Correcting the use of errors in `codec.go` won't actually help propagate the reason for the failure back to my device. In `packets.go`, there is a block of code that discards the lower-level error:

```
		pk.WillMessage, offset, err = decodeBytes(buf, offset)
		if err != nil {
			return ErrMalformedWillMessage
		}
```

I'm not sure what the authors wishes are here -- discarding the low-level error is certainly efficient but makes diagnostics more difficult. I would prefer to see

```
		pk.WillMessage, offset, err = decodeBytes(buf, offset)
		if err != nil {
			return fmt.Errorf("%s: %w", err, ErrMalformedWillMessage)
		}
```

This returns the high-level error type information to the caller while also returning the low-level error explanation to the user. The cost, of course, is more allocation. Since errors should be unexpected, I prefer to think of this as not a performance hit. 

If you approve, I would be glad to apply the above suggestion throughout `packets.go` in a future PR. 