### PR TITLE
ensures Add before Done; Wait before Close

### DIFF
--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -218,6 +218,8 @@ func (cl *Client) ForgetSubscription(filter string) {
 // Start begins the client goroutines reading and writing packets.
 func (cl *Client) Start() {
 	cl.State.started.Add(2)
+	cl.State.endedR.Add(1)
+	cl.State.endedW.Add(1)
 
 	go func() {
 		cl.State.started.Done()
@@ -225,7 +227,6 @@ func (cl *Client) Start() {
 		cl.State.endedW.Done()
 		cl.Stop()
 	}()
-	cl.State.endedW.Add(1)
 
 	go func() {
 		cl.State.started.Done()
@@ -233,7 +234,6 @@ func (cl *Client) Start() {
 		cl.State.endedR.Done()
 		cl.Stop()
 	}()
-	cl.State.endedR.Add(1)
 
 	cl.State.started.Wait()
 }
@@ -248,10 +248,10 @@ func (cl *Client) Stop() {
 		cl.r.Stop()
 		cl.w.Stop()
 		cl.State.endedW.Wait()
+		cl.State.endedR.Wait()
 
 		cl.conn.Close()
 
-		cl.State.endedR.Wait()
 		atomic.StoreUint32(&cl.State.Done, 1)
 	})
 }


### PR DESCRIPTION
This may not actually fix the problem I'm seeing, in fact I suspect I'm seeing two problems so not sure. I have a scenario where a client is quickly connecting and then closing the connection, and I see "write to close socket" happening during the flurry of errors. It appears that for every disconnect, there's a spurious error because of a race in which the reader hasn't finished before the close happens. 

It also looks like the Add() methods need to go before the goroutines start, in case of races described above.


<hr> 
Aside: @mochi-co I wonder if it would be possible for you to join the CNCF Slack workspace so that we could discuss in realtime?  You can find me there in the OpenTelemetry channels, https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/attend/slack-guidelines/.

As for why the client is quickly connecting and reconnecting, that appears to be a second matter and it may be that I'm 
doing something wrong. I am trying to follow the Spakplug specification for setting the STATE/host_id to ONLINE. I have my main application connect and publish "ONLINE" to that topic with a Will to publish OFFLINE to that topic when disconnected. The problem is that the OFFLINE will is being published after the reconnection begins, so that the OFFLINE will message is posted after the new ONLINE message. I'm not sure what's the correct thing to do here.

