### PR TITLE
Move two WaitGroup.Add calls

### DIFF
--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -218,6 +218,8 @@ func (cl *Client) ForgetSubscription(filter string) {
 // Start begins the client goroutines reading and writing packets.
 func (cl *Client) Start() {
 	cl.State.started.Add(2)
+	cl.State.endedW.Add(1)
+	cl.State.endedR.Add(1)
 
 	go func() {
 		cl.State.started.Done()
@@ -225,7 +227,6 @@ func (cl *Client) Start() {
 		cl.State.endedW.Done()
 		cl.Stop()
 	}()
-	cl.State.endedW.Add(1)
 
 	go func() {
 		cl.State.started.Done()
@@ -233,7 +234,6 @@ func (cl *Client) Start() {
 		cl.State.endedR.Done()
 		cl.Stop()
 	}()
-	cl.State.endedR.Add(1)
 
 	cl.State.started.Wait()
 }


### PR DESCRIPTION
Fixes most of #25. Extracted from #34.

The one (and only) test failure that I still see after this fix, also mentioned in #25, is:

```
--- FAIL: TestServerResendClientInflightBackoff (0.00s)
    server_test.go:2109: 
        	Error Trace:	server_test.go:2109
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	TestServerResendClientInflightBackoff
```