### PR TITLE
 Add an OnError handler, report the reason for disconnects

### DIFF
--- a/server/events/events.go
+++ b/server/events/events.go
@@ -1,12 +1,12 @@
 package events
 
 import (
-	"github.com/mochi-co/mqtt/server/internal/clients"
 	"github.com/mochi-co/mqtt/server/internal/packets"
 )
 
 type Events struct {
 	OnMessage    // published message receieved.
+	OnError      // server error.
 	OnConnect    // client connected.
 	OnDisconnect // client disconnected.
 }
@@ -15,15 +15,14 @@ type Packet packets.Packet
 
 type Client struct {
 	ID       string
+	Remote   string
 	Listener string
 }
 
-// FromClient returns an event client from a client.
-func FromClient(cl *clients.Client) Client {
-	return Client{
-		ID:       cl.ID,
-		Listener: cl.Listener,
-	}
+// Clientlike is an interface for Clients and client-like objects that
+// are able to describe their client/listener IDs and remote address.
+type Clientlike interface {
+	Info() Client
 }
 
 // OnMessage function is called when a publish message is received. Note,
@@ -44,3 +43,7 @@ type OnConnect func(Client, Packet)
 // is passed to the function if the client disconnected abnormally, otherwise it
 // will be nil on a normal disconnect.
 type OnDisconnect func(Client, error)
+
+// OnError is called when errors that will not be passed to
+// OnDisconnet are handled by the server.
+type OnError func(Client, error)

--- a/server/internal/circ/reader.go
+++ b/server/internal/circ/reader.go
@@ -60,7 +60,7 @@ func (b *Reader) ReadFrom(r io.Reader) (total int64, err error) {
 		n, err := r.Read(b.buf[start:end])
 		total += int64(n) // incr total bytes read.
 		if err != nil {
-			return total, nil
+			return total, err
 		}
 
 		// Move the head forward however many bytes were read.

--- a/server/internal/circ/reader_test.go
+++ b/server/internal/circ/reader_test.go
@@ -2,6 +2,8 @@ package circ
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -34,16 +36,18 @@ func TestReadFrom(t *testing.T) {
 	br := bytes.NewReader(b4)
 
 	_, err := buf.ReadFrom(br)
-	require.NoError(t, err)
+	require.True(t, errors.Is(err, io.EOF))
 	require.Equal(t, bytes.Repeat([]byte{'-'}, 4), buf.buf[:4])
 	require.Equal(t, int64(4), buf.head)
 
 	br.Reset(b4)
 	_, err = buf.ReadFrom(br)
+	require.True(t, errors.Is(err, io.EOF))
 	require.Equal(t, int64(8), buf.head)
 
 	br.Reset(b4)
 	_, err = buf.ReadFrom(br)
+	require.True(t, errors.Is(err, io.EOF))
 	require.Equal(t, int64(12), buf.head)
 }
 

--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rs/xid"
 
+	"github.com/mochi-co/mqtt/server/events"
 	"github.com/mochi-co/mqtt/server/internal/circ"
 	"github.com/mochi-co/mqtt/server/internal/packets"
 	"github.com/mochi-co/mqtt/server/internal/topics"
@@ -23,6 +24,8 @@ var (
 	// defaultKeepalive is the default connection keepalive value in seconds.
 	defaultKeepalive uint16 = 10
 
+	// ErrConnectionClosed is returned when operating on a closed
+	// connection and/or when no error cause has been given.
 	ErrConnectionClosed = errors.New("Connection not open")
 )
 
@@ -104,11 +107,12 @@ type Client struct {
 
 // State tracks the state of the client.
 type State struct {
-	started *sync.WaitGroup // tracks the goroutines which have been started.
-	endedW  *sync.WaitGroup // tracks when the writer has ended.
-	endedR  *sync.WaitGroup // tracks when the reader has ended.
-	Done    uint32          // atomic counter which indicates that the client has closed.
-	endOnce sync.Once       // only end once.
+	started   *sync.WaitGroup // tracks the goroutines which have been started.
+	endedW    *sync.WaitGroup // tracks when the writer has ended.
+	endedR    *sync.WaitGroup // tracks when the reader has ended.
+	Done      uint32          // atomic counter which indicates that the client has closed.
+	endOnce   sync.Once       // only end once.
+	stopCause atomic.Value    // reason for stopping (error).
 }
 
 // NewClient returns a new instance of Client.
@@ -185,7 +189,19 @@ func (cl *Client) refreshDeadline(keepalive uint16) {
 		if keepalive > 0 {
 			expiry = time.Now().Add(time.Duration(keepalive+(keepalive/2)) * time.Second)
 		}
-		cl.conn.SetDeadline(expiry)
+		_ = cl.conn.SetDeadline(expiry)
+	}
+}
+
+func (cl *Client) Info() events.Client {
+	addr := "unknown"
+	if cl.conn != nil && cl.conn.RemoteAddr() != nil {
+		addr = cl.conn.RemoteAddr().String()
+	}
+	return events.Client{
+		ID:       cl.ID,
+		Remote:   addr,
+		Listener: cl.Listener,
 	}
 }
 
@@ -218,38 +234,48 @@ func (cl *Client) ForgetSubscription(filter string) {
 // Start begins the client goroutines reading and writing packets.
 func (cl *Client) Start() {
 	cl.State.started.Add(2)
-
-	go func() {
-		cl.State.started.Done()
-		cl.w.WriteTo(cl.conn)
-		cl.State.endedW.Done()
-		cl.Stop()
-	}()
+	cl.State.endedR.Add(1)
 	cl.State.endedW.Add(1)
 
 	go func() {
 		cl.State.started.Done()
-		cl.r.ReadFrom(cl.conn)
-		cl.State.endedR.Done()
-		cl.Stop()
+		_, err := cl.w.WriteTo(cl.conn)
+		if err != nil {
+			err = fmt.Errorf("writer: %w", err)
+		}
+		cl.State.endedW.Done()
+		cl.Stop(err)
 	}()
-	cl.State.endedR.Add(1)
+
+	go func() {
+		cl.State.started.Done()
+		_, err := cl.r.ReadFrom(cl.conn)
+		if err != nil {
+			err = fmt.Errorf("reader: %w", err)
+		}
+		cl.State.endedR.Done()
+		cl.Stop(err)
+	}()
 
 	cl.State.started.Wait()
 }
 
 // Stop instructs the client to shut down all processing goroutines and disconnect.
-func (cl *Client) Stop() {
+func (cl *Client) Stop(cause error) {
 	if atomic.LoadUint32(&cl.State.Done) == 1 {
 		return
 	}
 
 	cl.State.endOnce.Do(func() {
+		if cause == nil {
+			cause = ErrConnectionClosed
+		}
+		cl.State.stopCause.Store(cause)
 		cl.r.Stop()
 		cl.w.Stop()
 		cl.State.endedW.Wait()
 
-		cl.conn.Close()
+		_ = cl.conn.Close()
 
 		cl.State.endedR.Wait()
 		atomic.StoreUint32(&cl.State.Done, 1)
@@ -303,6 +329,16 @@ func (cl *Client) ReadFixedHeader(fh *packets.FixedHeader) error {
 	atomic.AddInt64(&cl.systemInfo.BytesRecv, int64(n))
 
 	return nil
+}
+
+// StopCause returns the original reason that the client connection
+// stopped.
+func (cl *Client) StopCause() error {
+	cause := cl.State.stopCause.Load()
+	if cause == nil {
+		return nil
+	}
+	return cause.(error)
 }
 
 // Read loops forever reading new packets from a client connection until

--- a/server/listeners/tcp.go
+++ b/server/listeners/tcp.go
@@ -96,7 +96,9 @@ func (l *TCP) Serve(establish EstablishFunc) {
 		}
 
 		if atomic.LoadUint32(&l.end) == 0 {
-			go establish(l.id, conn, l.config.Auth)
+			go func() {
+				_ = establish(l.id, conn, l.config.Auth)
+			}()
 		}
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"sync/atomic"
@@ -30,6 +31,12 @@ var (
 	ErrReadConnectInvalid   = errors.New("Connect packet was not valid")
 	ErrConnectNotAuthorized = errors.New("Connect packet was not authorized")
 	ErrInvalidTopic         = errors.New("Cannot publish to $ and $SYS topics")
+
+	ErrClientDisconnect     = errors.New("Client disconnected")
+	ErrClientReconnect      = errors.New("Client attemped to reconnect")
+	ErrServerShutdown       = errors.New("Server is shutting down")
+	ErrSessionReestablished = errors.New("Session reestablished")
+	ErrConnectionFailed     = errors.New("Connection attempt failed")
 
 	// SysTopicInterval is the number of milliseconds between $SYS topic publishes.
 	SysTopicInterval time.Duration = 30000
@@ -166,6 +173,46 @@ func (s *Server) inlineClient() {
 	}
 }
 
+func (s *Server) connSetup(cl *clients.Client) (packets.Packet, error) {
+	fh := new(packets.FixedHeader)
+	if err := cl.ReadFixedHeader(fh); err != nil {
+		return packets.Packet{}, err
+	}
+
+	pk, err := cl.ReadPacket(fh)
+	if err != nil {
+		return pk, err
+	}
+
+	if pk.FixedHeader.Type != packets.Connect {
+		return pk, ErrReadConnectInvalid
+	}
+	return pk, nil
+}
+
+func (s *Server) onError(cl events.Client, err error) error {
+	if err == nil {
+		return err
+	}
+	// Note: if the error originates from a real cause, it will
+	// have been captured as the StopCause.  The two cases ignored
+	// below are ordinary consequences of closing the connection.
+	// If one of these ordinary conditions stops the connection,
+	// then the client closed or broke the connection.
+	if s.Events.OnError != nil &&
+		!errors.Is(err, io.EOF) {
+		s.Events.OnError(cl, err)
+	}
+	return err
+}
+
+func (s *Server) onStorage(cl events.Clientlike, err error) {
+	if err == nil {
+		return
+	}
+	_ = s.onError(cl.Info(), fmt.Errorf("storage: %w", err))
+}
+
 // EstablishConnection establishes a new client when a listener
 // accepts a new connection.
 func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller) error {
@@ -180,19 +227,9 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 
 	cl.Start()
 
-	fh := new(packets.FixedHeader)
-	err := cl.ReadFixedHeader(fh)
+	pk, err := s.connSetup(cl)
 	if err != nil {
-		return err
-	}
-
-	pk, err := cl.ReadPacket(fh)
-	if err != nil {
-		return err
-	}
-
-	if pk.FixedHeader.Type != packets.Connect {
-		return ErrReadConnectInvalid
+		return s.onError(cl.Info(), fmt.Errorf("setup: %w", err))
 	}
 
 	cl.Identify(lid, pk, ac)
@@ -211,7 +248,7 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 		if atomic.LoadUint32(&existing.State.Done) == 1 {
 			atomic.AddInt64(&s.System.ClientsDisconnected, -1)
 		}
-		existing.Stop()
+		existing.Stop(fmt.Errorf("connection from %s: %w", cl.Info().Remote, ErrSessionReestablished))
 		if pk.CleanSession {
 			for k := range existing.Subscriptions {
 				delete(existing.Subscriptions, k)
@@ -235,38 +272,45 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 
 	s.Clients.Add(cl) // Overwrite any existing client with the same name.
 
-	err = s.writeClient(cl, packets.Packet{
+	if err := s.writeClient(cl, packets.Packet{
 		FixedHeader: packets.FixedHeader{
 			Type: packets.Connack,
 		},
 		SessionPresent: sessionPresent,
 		ReturnCode:     retcode,
-	})
-	if err != nil || retcode != packets.Accepted {
-		return err
+	}); err != nil {
+		return s.onError(cl.Info(), err)
+	}
+	if retcode != packets.Accepted {
+		err = ErrConnectionFailed
+		return s.onError(cl.Info(), err)
 	}
 
-	s.ResendClientInflight(cl, true)
+	if err := s.ResendClientInflight(cl, true); err != nil {
+		err = fmt.Errorf("resend in flight: %w ", err)
+		s.onError(cl.Info(), err)
+		// Note: Pass through after resend error.
+	}
 
 	if s.Store != nil {
-		s.Store.WriteClient(persistence.Client{
+		s.onStorage(cl, s.Store.WriteClient(persistence.Client{
 			ID:       "cl_" + cl.ID,
 			ClientID: cl.ID,
 			T:        persistence.KClient,
 			Listener: cl.Listener,
 			Username: cl.Username,
 			LWT:      persistence.LWT(cl.LWT),
-		})
+		}))
 	}
 
 	if s.Events.OnConnect != nil {
-		s.Events.OnConnect(events.FromClient(cl), events.Packet(pk))
+		s.Events.OnConnect(cl.Info(), events.Packet(pk))
 	}
 
-	err = cl.Read(s.processPacket)
-	if err != nil {
-		s.closeClient(cl, true)
+	if err := cl.Read(s.processPacket); err != nil {
+		s.closeClient(cl, true, err)
 	}
+	err = cl.StopCause()
 
 	s.bytepool.Put(xbr) // Return byte buffers to pools when the client has finished.
 	s.bytepool.Put(xbw)
@@ -275,7 +319,7 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 	atomic.AddInt64(&s.System.ClientsDisconnected, 1)
 
 	if s.Events.OnDisconnect != nil {
-		s.Events.OnDisconnect(events.FromClient(cl), err)
+		s.Events.OnDisconnect(cl.Info(), err)
 	}
 
 	return err
@@ -285,10 +329,9 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 func (s *Server) writeClient(cl *clients.Client, pk packets.Packet) error {
 	_, err := cl.WritePacket(pk)
 	if err != nil {
-		return err
+		return fmt.Errorf("write: %w", err)
 	}
-
-	return nil
+	return err
 }
 
 // processPacket processes an inbound packet for a client. Since the method is
@@ -336,13 +379,13 @@ func (s *Server) processPacket(cl *clients.Client, pk packets.Packet) error {
 // establish a new connection on an existing connection. See EstablishConnection
 // instead.
 func (s *Server) processConnect(cl *clients.Client, pk packets.Packet) error {
-	s.closeClient(cl, true)
+	s.closeClient(cl, true, ErrClientReconnect)
 	return nil
 }
 
 // processDisconnect processes a Disconnect packet.
 func (s *Server) processDisconnect(cl *clients.Client, pk packets.Packet) error {
-	s.closeClient(cl, false)
+	s.closeClient(cl, false, ErrClientDisconnect)
 	return nil
 }
 
@@ -378,7 +421,7 @@ func (s *Server) Publish(topic string, payload []byte, retain bool) error {
 	}
 
 	if retain {
-		s.retainMessage(pk)
+		s.retainMessage(&s.inline, pk)
 	}
 
 	// handoff packet to s.inline.pub channel for writing to client buffers
@@ -386,6 +429,14 @@ func (s *Server) Publish(topic string, payload []byte, retain bool) error {
 	s.inline.pub <- pk
 
 	return nil
+}
+
+func (*inlineMessages) Info() events.Client {
+	return events.Client{
+		"inline",
+		"inline",
+		"inline",
+	}
 }
 
 // processPublish processes a Publish packet.
@@ -399,7 +450,7 @@ func (s *Server) processPublish(cl *clients.Client, pk packets.Packet) error {
 	}
 
 	if pk.FixedHeader.Retain {
-		s.retainMessage(pk)
+		s.retainMessage(cl, pk)
 	}
 
 	if pk.FixedHeader.Qos > 0 {
@@ -416,12 +467,12 @@ func (s *Server) processPublish(cl *clients.Client, pk packets.Packet) error {
 
 		// omit errors in case of broken connection / LWT publish. ack send failures
 		// will be handled by in-flight resending on next reconnect.
-		s.writeClient(cl, ack)
+		s.onError(cl.Info(), s.writeClient(cl, ack))
 	}
 
 	// if an OnMessage hook exists, potentially modify the packet.
 	if s.Events.OnMessage != nil {
-		if pkx, err := s.Events.OnMessage(events.FromClient(cl), events.Packet(pk)); err == nil {
+		if pkx, err := s.Events.OnMessage(cl.Info(), events.Packet(pk)); err == nil {
 			pk = packets.Packet(pkx)
 		}
 	}
@@ -434,21 +485,21 @@ func (s *Server) processPublish(cl *clients.Client, pk packets.Packet) error {
 
 // retainMessage adds a message to a topic, and if a persistent store is provided,
 // adds the message to the store so it can be reloaded if necessary.
-func (s *Server) retainMessage(pk packets.Packet) {
+func (s *Server) retainMessage(cl events.Clientlike, pk packets.Packet) {
 	out := pk.PublishCopy()
 	q := s.Topics.RetainMessage(out)
 	atomic.AddInt64(&s.System.Retained, q)
 	if s.Store != nil {
 		if q == 1 {
-			s.Store.WriteRetained(persistence.Message{
+			s.onStorage(cl, s.Store.WriteRetained(persistence.Message{
 				ID:          "ret_" + out.TopicName,
 				T:           persistence.KRetained,
 				FixedHeader: persistence.FixedHeader(out.FixedHeader),
 				TopicName:   out.TopicName,
 				Payload:     out.Payload,
-			})
+			}))
 		} else {
-			s.Store.DeleteRetained("ret_" + out.TopicName)
+			s.onStorage(cl, s.Store.DeleteRetained("ret_"+out.TopicName))
 		}
 	}
 }
@@ -490,18 +541,18 @@ func (s *Server) publishToSubscribers(pk packets.Packet) {
 				}
 
 				if s.Store != nil {
-					s.Store.WriteInflight(persistence.Message{
+					s.onStorage(client, s.Store.WriteInflight(persistence.Message{
 						ID:          "if_" + client.ID + "_" + strconv.Itoa(int(out.PacketID)),
 						T:           persistence.KRetained,
 						FixedHeader: persistence.FixedHeader(out.FixedHeader),
 						TopicName:   out.TopicName,
 						Payload:     out.Payload,
 						Sent:        sent,
-					})
+					}))
 				}
 			}
 
-			s.writeClient(client, out)
+			s.onError(client.Info(), s.writeClient(client, out))
 		}
 	}
 }
@@ -513,7 +564,7 @@ func (s *Server) processPuback(cl *clients.Client, pk packets.Packet) error {
 		atomic.AddInt64(&s.System.Inflight, -1)
 	}
 	if s.Store != nil {
-		s.Store.DeleteInflight("if_" + cl.ID + "_" + strconv.Itoa(int(pk.PacketID)))
+		s.onStorage(cl, s.Store.DeleteInflight("if_"+cl.ID+"_"+strconv.Itoa(int(pk.PacketID))))
 	}
 	return nil
 }
@@ -555,7 +606,7 @@ func (s *Server) processPubrel(cl *clients.Client, pk packets.Packet) error {
 	}
 
 	if s.Store != nil {
-		s.Store.DeleteInflight("if_" + cl.ID + "_" + strconv.Itoa(int(pk.PacketID)))
+		s.onStorage(cl, s.Store.DeleteInflight("if_"+cl.ID+"_"+strconv.Itoa(int(pk.PacketID))))
 	}
 
 	return nil
@@ -568,7 +619,7 @@ func (s *Server) processPubcomp(cl *clients.Client, pk packets.Packet) error {
 		atomic.AddInt64(&s.System.Inflight, -1)
 	}
 	if s.Store != nil {
-		s.Store.DeleteInflight("if_" + cl.ID + "_" + strconv.Itoa(int(pk.PacketID)))
+		s.onStorage(cl, s.Store.DeleteInflight("if_"+cl.ID+"_"+strconv.Itoa(int(pk.PacketID))))
 	}
 	return nil
 }
@@ -588,13 +639,13 @@ func (s *Server) processSubscribe(cl *clients.Client, pk packets.Packet) error {
 			retCodes[i] = pk.Qoss[i]
 
 			if s.Store != nil {
-				s.Store.WriteSubscription(persistence.Subscription{
+				s.onStorage(cl, s.Store.WriteSubscription(persistence.Subscription{
 					ID:     "sub_" + cl.ID + ":" + pk.Topics[i],
 					T:      persistence.KSubscription,
 					Filter: pk.Topics[i],
 					Client: cl.ID,
 					QoS:    pk.Qoss[i],
-				})
+				}))
 			}
 		}
 	}
@@ -613,7 +664,7 @@ func (s *Server) processSubscribe(cl *clients.Client, pk packets.Packet) error {
 	// Publish out any retained messages matching the subscription filter.
 	for i := 0; i < len(pk.Topics); i++ {
 		for _, pkv := range s.Topics.Messages(pk.Topics[i]) {
-			s.writeClient(cl, pkv) // omit errors, prefer continuing.
+			s.onError(cl.Info(), s.writeClient(cl, pkv))
 		}
 	}
 
@@ -685,10 +736,10 @@ func (s *Server) publishSysTopics() {
 	}
 
 	if s.Store != nil {
-		s.Store.WriteServerInfo(persistence.ServerInfo{
+		s.onStorage(&s.inline, s.Store.WriteServerInfo(persistence.ServerInfo{
 			Info: *s.System,
 			ID:   persistence.KServerInfo,
-		})
+		}))
 	}
 }
 
@@ -708,7 +759,7 @@ func (s *Server) ResendClientInflight(cl *clients.Client, force bool) error {
 			}
 
 			if s.Store != nil {
-				s.Store.DeleteInflight("if_" + cl.ID + "_" + strconv.Itoa(int(tk.Packet.PacketID)))
+				s.onStorage(cl, s.Store.DeleteInflight("if_"+cl.ID+"_"+strconv.Itoa(int(tk.Packet.PacketID))))
 			}
 
 			continue
@@ -732,7 +783,7 @@ func (s *Server) ResendClientInflight(cl *clients.Client, force bool) error {
 		}
 
 		if s.Store != nil {
-			s.Store.WriteInflight(persistence.Message{
+			s.onStorage(cl, s.Store.WriteInflight(persistence.Message{
 				ID:          "if_" + cl.ID + "_" + strconv.Itoa(int(tk.Packet.PacketID)),
 				T:           persistence.KRetained,
 				FixedHeader: persistence.FixedHeader(tk.Packet.FixedHeader),
@@ -740,7 +791,7 @@ func (s *Server) ResendClientInflight(cl *clients.Client, force bool) error {
 				Payload:     tk.Packet.Payload,
 				Sent:        tk.Sent,
 				Resends:     tk.Resends,
-			})
+			}))
 		}
 	}
 
@@ -763,15 +814,14 @@ func (s *Server) Close() error {
 func (s *Server) closeListenerClients(listener string) {
 	clients := s.Clients.GetByListener(listener)
 	for _, cl := range clients {
-		s.closeClient(cl, false) // omit errors
+		s.closeClient(cl, false, ErrServerShutdown)
 	}
-
 }
 
 // closeClient closes a client connection and publishes any LWT messages.
-func (s *Server) closeClient(cl *clients.Client, sendLWT bool) error {
+func (s *Server) closeClient(cl *clients.Client, sendLWT bool, cause error) {
 	if sendLWT && cl.LWT.Topic != "" {
-		s.processPublish(cl, packets.Packet{
+		if err := s.processPublish(cl, packets.Packet{
 			FixedHeader: packets.FixedHeader{
 				Type:   packets.Publish,
 				Retain: cl.LWT.Retain,
@@ -779,12 +829,12 @@ func (s *Server) closeClient(cl *clients.Client, sendLWT bool) error {
 			},
 			TopicName: cl.LWT.Topic,
 			Payload:   cl.LWT.Message,
-		})
+		}); err != nil {
+			s.onError(cl.Info(), fmt.Errorf("publish will: %w", err))
+		}
 	}
 
-	cl.Stop()
-
-	return nil
+	cl.Stop(cause)
 }
 
 // readStore reads in any data from the persistent datastore (if applicable).

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,11 +1,13 @@
 package server
 
 import (
-	//"errors"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,6 +24,41 @@ import (
 	"github.com/mochi-co/mqtt/server/persistence"
 	"github.com/mochi-co/mqtt/server/system"
 )
+
+type packetHook struct {
+	lock   sync.Mutex
+	client events.Client
+	packet events.Packet
+}
+
+func (h *packetHook) onPacket(cl events.Client, pk events.Packet) (events.Packet, error) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.client = cl
+	h.packet = pk
+	return pk, nil
+}
+
+func (h *packetHook) onConnect(cl events.Client, pk events.Packet) {
+	h.onPacket(cl, pk)
+}
+
+type errorHook struct {
+	lock   sync.Mutex
+	client events.Client
+	err    error
+	cnt    int
+}
+
+func (h *errorHook) onError(cl events.Client, err error) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.client = cl
+	h.err = err
+	h.cnt++
+}
+
+var errTestStop = fmt.Errorf("test stop")
 
 const defaultPort = ":18882"
 
@@ -171,6 +208,11 @@ func BenchmarkServerServe(b *testing.B) {
 	}
 }
 
+func TestServerInlineInfo(t *testing.T) {
+	s := New()
+	require.Equal(t, events.Client{"inline", "inline", "inline"}, s.inline.Info())
+}
+
 func TestServerEstablishConnectionOKCleanSession(t *testing.T) {
 	s := New()
 
@@ -216,10 +258,10 @@ func TestServerEstablishConnectionOKCleanSession(t *testing.T) {
 
 	clw, ok := s.Clients.Get("mochi")
 	require.Equal(t, true, ok)
-	clw.Stop()
 
 	errx := <-o
-	require.NoError(t, errx)
+	require.True(t, errors.Is(errx, ErrClientDisconnect))
+
 	require.Equal(t, []byte{
 		byte(packets.Connack << 4), 2,
 		0, packets.Accepted,
@@ -234,12 +276,8 @@ func TestServerEventOnConnect(t *testing.T) {
 	s, cl, _, _ := setupClient()
 	s.Clients.Add(cl)
 
-	var hookedClient events.Client
-	var hookedPacket events.Packet
-	s.Events.OnConnect = func(cl events.Client, pk events.Packet) {
-		hookedClient = cl
-		hookedPacket = pk
-	}
+	var hook packetHook
+	s.Events.OnConnect = hook.onConnect
 
 	o := make(chan error)
 	go func() {
@@ -272,10 +310,9 @@ func TestServerEventOnConnect(t *testing.T) {
 
 	clw, ok := s.Clients.Get("mochi")
 	require.Equal(t, true, ok)
-	clw.Stop()
 
 	errx := <-o
-	require.NoError(t, errx)
+	require.True(t, errors.Is(errx, ErrClientDisconnect))
 	require.Equal(t, []byte{
 		byte(packets.Connack << 4), 2,
 		0, packets.Accepted,
@@ -288,8 +325,9 @@ func TestServerEventOnConnect(t *testing.T) {
 
 	require.Equal(t, events.Client{
 		ID:       "mochi",
+		Remote:   "pipe",
 		Listener: "tcp",
-	}, hookedClient)
+	}, hook.client)
 
 	require.Equal(t, events.Packet(packets.Packet{
 		FixedHeader: packets.FixedHeader{
@@ -301,7 +339,7 @@ func TestServerEventOnConnect(t *testing.T) {
 		CleanSession:     true,
 		Keepalive:        45,
 		ClientIdentifier: "mochi",
-	}), hookedPacket)
+	}), hook.packet)
 
 }
 
@@ -310,12 +348,8 @@ func TestServerEventOnDisconnect(t *testing.T) {
 	s, cl, _, _ := setupClient()
 	s.Clients.Add(cl)
 
-	var hookedClient events.Client
-	var hookedErr error
-	s.Events.OnDisconnect = func(cl events.Client, err error) {
-		hookedClient = cl
-		hookedErr = err
-	}
+	var hook errorHook
+	s.Events.OnDisconnect = hook.onError
 
 	o := make(chan error)
 	go func() {
@@ -348,10 +382,9 @@ func TestServerEventOnDisconnect(t *testing.T) {
 
 	clw, ok := s.Clients.Get("mochi")
 	require.Equal(t, true, ok)
-	clw.Stop()
 
 	errx := <-o
-	require.NoError(t, errx)
+	require.True(t, errors.Is(errx, ErrClientDisconnect))
 
 	require.Equal(t, []byte{
 		byte(packets.Connack << 4), 2,
@@ -363,10 +396,11 @@ func TestServerEventOnDisconnect(t *testing.T) {
 
 	require.Equal(t, events.Client{
 		ID:       "mochi",
+		Remote:   "pipe",
 		Listener: "tcp",
-	}, hookedClient)
+	}, hook.client)
 
-	require.Equal(t, nil, hookedErr)
+	require.True(t, errors.Is(hook.err, ErrClientDisconnect))
 }
 
 func TestServerEventOnDisconnectOnError(t *testing.T) {
@@ -374,12 +408,13 @@ func TestServerEventOnDisconnectOnError(t *testing.T) {
 	s, cl, _, _ := setupClient()
 	s.Clients.Add(cl)
 
-	var hookedClient events.Client
-	var hookedErr error
-	s.Events.OnDisconnect = func(cl events.Client, err error) {
-		hookedClient = cl
-		hookedErr = err
+	s.Events.OnError = func(cl events.Client, err error) {
+		// Do not allow
+		panic(err)
 	}
+
+	var hook errorHook
+	s.Events.OnDisconnect = hook.onError
 
 	o := make(chan error)
 	go func() {
@@ -409,21 +444,19 @@ func TestServerEventOnDisconnectOnError(t *testing.T) {
 		}
 	}()
 
-	clw, ok := s.Clients.Get("mochi")
+	_, ok := s.Clients.Get("mochi")
 	require.Equal(t, true, ok)
-	clw.Stop()
 
 	errx := <-o
 	require.Error(t, errx)
 	require.Equal(t, "No valid packet available; 0", errx.Error())
-
-	require.Equal(t, errx, hookedErr)
+	require.Equal(t, errx, hook.err)
 
 	require.Equal(t, events.Client{
 		ID:       "mochi",
+		Remote:   "pipe",
 		Listener: "tcp",
-	}, hookedClient)
-
+	}, hook.client)
 }
 
 func TestServerEstablishConnectionOKInheritSession(t *testing.T) {
@@ -469,10 +502,9 @@ func TestServerEstablishConnectionOKInheritSession(t *testing.T) {
 
 	clw, ok := s.Clients.Get("mochi")
 	require.Equal(t, true, ok)
-	clw.Stop()
 
 	errx := <-o
-	require.NoError(t, errx)
+	require.True(t, errors.Is(errx, ErrClientDisconnect))
 	require.Equal(t, []byte{
 		byte(packets.Connack << 4), 2,
 		1, packets.Accepted,
@@ -485,6 +517,10 @@ func TestServerEstablishConnectionOKInheritSession(t *testing.T) {
 func TestServerEstablishConnectionBadFixedHeader(t *testing.T) {
 	s := New()
 
+	var hookE, hookD errorHook
+	s.Events.OnError = hookE.onError
+	s.Events.OnDisconnect = hookD.onError
+
 	r, w := net.Pipe()
 	go func() {
 		w.Write([]byte{packets.Connect<<4 | 1<<1, 0x00, 0x00})
@@ -495,7 +531,12 @@ func TestServerEstablishConnectionBadFixedHeader(t *testing.T) {
 
 	r.Close()
 	require.Error(t, err)
-	require.Equal(t, packets.ErrInvalidFlags, err)
+	require.True(t, errors.Is(err, packets.ErrInvalidFlags))
+
+	require.Equal(t, err, hookE.err)
+
+	// There was no disconnect error b/c connection failed.
+	require.Nil(t, hookD.err)
 }
 
 func TestServerEstablishConnectionInvalidPacket(t *testing.T) {
@@ -528,7 +569,7 @@ func TestServerEstablishConnectionNotConnectPacket(t *testing.T) {
 
 	r.Close()
 	require.Error(t, err)
-	require.Equal(t, ErrReadConnectInvalid, err)
+	require.True(t, errors.Is(err, ErrReadConnectInvalid))
 }
 
 func TestServerEstablishConnectionBadAuth(t *testing.T) {
@@ -570,7 +611,7 @@ func TestServerEstablishConnectionBadAuth(t *testing.T) {
 	errx := <-o
 	time.Sleep(time.Millisecond)
 	r.Close()
-	require.NoError(t, errx)
+	require.True(t, errors.Is(errx, ErrConnectionFailed))
 	require.Equal(t, []byte{
 		byte(packets.Connack << 4), 2,
 		0, packets.CodeConnectBadAuthValues,
@@ -639,14 +680,9 @@ func TestServerEstablishConnectionReadPacketErr(t *testing.T) {
 	require.Error(t, errx)
 }
 
-func TestServerOnDisconnectErr(t *testing.T) {
-
-}
-
 func TestServerWriteClient(t *testing.T) {
 	s, cl, r, w := setupClient()
 	cl.ID = "mochi"
-	defer cl.Stop()
 
 	err := s.writeClient(cl, packets.Packet{
 		FixedHeader: packets.FixedHeader{
@@ -657,21 +693,19 @@ func TestServerWriteClient(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ack := make(chan []byte)
-	go func() {
-		buf, err := ioutil.ReadAll(r)
-		if err != nil {
-			panic(err)
-		}
-		ack <- buf
-	}()
-	time.Sleep(time.Millisecond)
-	w.Close()
+	// Expecting 4 bytes
+	buf := make([]byte, 4)
+	nread, err := r.Read(buf)
+	if nread < 4 || err != nil {
+		panic(err)
+	}
 
 	require.Equal(t, []byte{
 		byte(packets.Pubcomp << 4), 2,
 		0, 14,
-	}, <-ack)
+	}, buf)
+
+	w.Close()
 }
 
 func TestServerWriteClientError(t *testing.T) {
@@ -740,13 +774,14 @@ func TestServerProcessPingreq(t *testing.T) {
 func TestServerProcessPingreqError(t *testing.T) {
 	s, cl, _, _ := setupClient()
 
-	cl.Stop()
+	cl.Stop(errTestStop)
 	err := s.processPacket(cl, packets.Packet{
 		FixedHeader: packets.FixedHeader{
 			Type: packets.Pingreq,
 		},
 	})
 	require.Error(t, err)
+	require.Equal(t, errTestStop, cl.StopCause())
 }
 
 func TestServerProcessPublishInvalid(t *testing.T) {
@@ -903,7 +938,7 @@ func TestServerProcessPublishOfflineQueuing(t *testing.T) {
 	s.Topics.Subscribe("qos0", cl2.ID, 0)
 	s.Topics.Subscribe("qos1", cl2.ID, 1)
 	s.Topics.Subscribe("qos2", cl2.ID, 2)
-	cl2.Stop()
+	cl2.Stop(errTestStop)
 
 	ack1 := make(chan []byte)
 	go func() {
@@ -976,10 +1011,10 @@ func TestServerProcessPublishOfflineQueuing(t *testing.T) {
 
 	clw, ok := s.Clients.Get("mochi2")
 	require.Equal(t, true, ok)
-	clw.Stop()
+	clw.Stop(errTestStop)
 
 	errx := <-o
-	require.NoError(t, errx)
+	require.True(t, errors.Is(errx, ErrClientDisconnect))
 	ret := <-recv
 
 	wanted := []byte{
@@ -1001,7 +1036,6 @@ func TestServerProcessPublishOfflineQueuing(t *testing.T) {
 	require.Equal(t, true, (ret[4] == byte(packets.Publish<<4|1<<1|1<<3) || ret[4] == byte(packets.Publish<<4|2<<1|1<<3)))
 
 	w.Close()
-
 }
 
 func TestServerProcessPublishSystemPrefix(t *testing.T) {
@@ -1038,7 +1072,7 @@ func TestServerProcessPublishBadACL(t *testing.T) {
 
 func TestServerProcessPublishWriteAckError(t *testing.T) {
 	s, cl, _, _ := setupClient()
-	cl.Stop()
+	cl.Stop(errTestStop)
 
 	err := s.processPacket(cl, packets.Packet{
 		FixedHeader: packets.FixedHeader{
@@ -1050,6 +1084,7 @@ func TestServerProcessPublishWriteAckError(t *testing.T) {
 	})
 
 	require.Error(t, err)
+	require.Equal(t, errTestStop, cl.StopCause())
 }
 
 func TestServerPublishInline(t *testing.T) {
@@ -1081,7 +1116,8 @@ func TestServerPublishInline(t *testing.T) {
 		'h', 'e', 'l', 'l', 'o',
 	}, <-ack1)
 
-	require.Equal(t, int64(14), s.System.BytesSent)
+	bsent := atomic.LoadInt64(&s.System.BytesSent)
+	require.Equal(t, int64(14), bsent)
 
 	close(s.inline.done)
 }
@@ -1137,13 +1173,8 @@ func TestServerEventOnMessage(t *testing.T) {
 	s.Clients.Add(cl1)
 	s.Topics.Subscribe("a/b/+", cl1.ID, 0)
 
-	var hookedPacket events.Packet
-	var hookedClient events.Client
-	s.Events.OnMessage = func(cl events.Client, pk events.Packet) (events.Packet, error) {
-		hookedClient = cl
-		hookedPacket = pk
-		return pk, nil
-	}
+	var hook packetHook
+	s.Events.OnMessage = hook.onPacket
 
 	ack1 := make(chan []byte)
 	go func() {
@@ -1168,10 +1199,11 @@ func TestServerEventOnMessage(t *testing.T) {
 
 	require.Equal(t, events.Client{
 		ID:       "mochi",
+		Remote:   "pipe",
 		Listener: "",
-	}, hookedClient)
+	}, hook.client)
 
-	require.Equal(t, events.Packet(pk1), hookedPacket)
+	require.Equal(t, events.Packet(pk1), hook.packet)
 
 	w1.Close()
 
@@ -1190,13 +1222,12 @@ func TestServerProcessPublishHookOnMessageModify(t *testing.T) {
 	s.Clients.Add(cl1)
 	s.Topics.Subscribe("a/b/+", cl1.ID, 0)
 
-	var hookedPacket events.Packet
 	var hookedClient events.Client
 	s.Events.OnMessage = func(cl events.Client, pk events.Packet) (events.Packet, error) {
-		hookedPacket = pk
-		hookedPacket.Payload = []byte("world")
+		pkx := pk
+		pkx.Payload = []byte("world")
 		hookedClient = cl
-		return hookedPacket, nil
+		return pkx, nil
 	}
 
 	ack1 := make(chan []byte)
@@ -1222,6 +1253,7 @@ func TestServerProcessPublishHookOnMessageModify(t *testing.T) {
 
 	require.Equal(t, events.Client{
 		ID:       "mochi",
+		Remote:   "pipe",
 		Listener: "",
 	}, hookedClient)
 
@@ -1294,11 +1326,10 @@ func TestServerProcessPublishHookOnMessageAllowClients(t *testing.T) {
 	s.Topics.Subscribe("d/e/f", cl2.ID, 0)
 
 	s.Events.OnMessage = func(cl events.Client, pk events.Packet) (events.Packet, error) {
-		hookedPacket := pk
 		if pk.TopicName == "a/b/c" {
-			hookedPacket.AllowClients = []string{"allowed"}
+			pk.AllowClients = []string{"allowed"}
 		}
-		return hookedPacket, nil
+		return pk, nil
 	}
 
 	ack1 := make(chan []byte)
@@ -1415,7 +1446,7 @@ func TestServerProcessPubrec(t *testing.T) {
 
 func TestServerProcessPubrecError(t *testing.T) {
 	s, cl, _, _ := setupClient()
-	cl.Stop()
+	cl.Stop(errTestStop)
 	cl.Inflight.Set(12, clients.InflightMessage{Packet: packets.Packet{PacketID: 12}, Sent: 0})
 
 	err := s.processPacket(cl, packets.Packet{
@@ -1425,6 +1456,7 @@ func TestServerProcessPubrecError(t *testing.T) {
 		PacketID: 12,
 	})
 	require.Error(t, err)
+	require.Equal(t, errTestStop, cl.StopCause())
 }
 
 func TestServerProcessPubrel(t *testing.T) {
@@ -1461,7 +1493,7 @@ func TestServerProcessPubrel(t *testing.T) {
 
 func TestServerProcessPubrelError(t *testing.T) {
 	s, cl, _, _ := setupClient()
-	cl.Stop()
+	cl.Stop(errTestStop)
 	cl.Inflight.Set(12, clients.InflightMessage{Packet: packets.Packet{PacketID: 12}, Sent: 0})
 
 	err := s.processPacket(cl, packets.Packet{
@@ -1471,6 +1503,7 @@ func TestServerProcessPubrelError(t *testing.T) {
 		PacketID: 12,
 	})
 	require.Error(t, err)
+	require.Equal(t, errTestStop, cl.StopCause())
 }
 
 func TestServerProcessPubcomp(t *testing.T) {
@@ -1599,7 +1632,7 @@ func TestServerProcessSubscribeFailACL(t *testing.T) {
 
 func TestServerProcessSubscribeWriteError(t *testing.T) {
 	s, cl, _, _ := setupClient()
-	cl.Stop()
+	cl.Stop(errTestStop)
 
 	err := s.processPacket(cl, packets.Packet{
 		FixedHeader: packets.FixedHeader{
@@ -1611,6 +1644,7 @@ func TestServerProcessSubscribeWriteError(t *testing.T) {
 	})
 
 	require.Error(t, err)
+	require.Equal(t, errTestStop, cl.StopCause())
 }
 
 func TestServerProcessUnsubscribeInvalid(t *testing.T) {
@@ -1674,7 +1708,7 @@ func TestServerProcessUnsubscribe(t *testing.T) {
 
 func TestServerProcessUnsubscribeWriteError(t *testing.T) {
 	s, cl, _, _ := setupClient()
-	cl.Stop()
+	cl.Stop(errTestStop)
 
 	err := s.processPacket(cl, packets.Packet{
 		FixedHeader: packets.FixedHeader{
@@ -1685,6 +1719,7 @@ func TestServerProcessUnsubscribeWriteError(t *testing.T) {
 	})
 
 	require.Error(t, err)
+	require.Equal(t, errTestStop, cl.StopCause())
 }
 
 func TestEventLoop(t *testing.T) {
@@ -1696,7 +1731,6 @@ func TestEventLoop(t *testing.T) {
 	}()
 	time.Sleep(time.Millisecond * 3)
 	close(s.done)
-
 }
 
 func TestServerClose(t *testing.T) {
@@ -1748,8 +1782,7 @@ func TestServerCloseClientLWT(t *testing.T) {
 		ack2 <- buf
 	}()
 
-	err := s.closeClient(cl1, true)
-	require.NoError(t, err)
+	s.closeClient(cl1, true, fmt.Errorf("goodbye"))
 	time.Sleep(time.Millisecond)
 	w2.Close()
 
@@ -1763,16 +1796,28 @@ func TestServerCloseClientLWT(t *testing.T) {
 
 func TestServerCloseClientClosed(t *testing.T) {
 	s, cl, _, _ := setupClient()
+
+	var hook errorHook
+	s.Events.OnError = hook.onError
+
 	cl.Listener = "t1"
 	cl.LWT = clients.LWT{
 		Qos:     1,
 		Topic:   "a/b/c",
 		Message: []byte{'h', 'e', 'l', 'l', 'o'},
 	}
-	cl.Stop()
+	// Close the client connection abruptly, e.g., as if the
+	// seession were taken over or a protocol error had occurred.
+	cl.Stop(errTestStop)
 
-	err := s.closeClient(cl, true)
-	require.NoError(t, err)
+	s.closeClient(cl, true, clients.ErrConnectionClosed)
+
+	// We see the original error that caused the connection to stop.
+	require.True(t, errors.Is(cl.StopCause(), errTestStop) || errors.Is(cl.StopCause(), io.EOF))
+
+	// Errors were generated in the closeClient() code path.
+	require.Equal(t, 1, hook.cnt)
+	require.True(t, errors.Is(hook.err, clients.ErrConnectionClosed))
 }
 
 func TestServerReadStore(t *testing.T) {
@@ -2032,6 +2077,7 @@ func TestServerResendClientInflight(t *testing.T) {
 	require.NoError(t, err)
 
 	time.Sleep(time.Millisecond)
+
 	r.Close()
 
 	rcv := <-o
@@ -2045,13 +2091,19 @@ func TestServerResendClientInflight(t *testing.T) {
 
 	m := cl.Inflight.GetAll()
 	require.Equal(t, 1, m[11].Resends) // index is packet id
-
 }
 
 func TestServerResendClientInflightBackoff(t *testing.T) {
 	s := New()
-	s.Store = new(persistence.MockStore)
 	require.NotNil(t, s)
+
+	mock := new(persistence.MockStore)
+	s.Store = mock
+	mock.Fail = make(map[string]bool)
+	mock.Fail["write_inflight"] = true
+
+	var hook errorHook
+	s.Events.OnError = hook.onError
 
 	r, w := net.Pipe()
 	cl := clients.NewClient(r, circ.NewReader(128, 8), circ.NewWriter(128, 8), new(system.Info))
@@ -2103,6 +2155,9 @@ func TestServerResendClientInflightBackoff(t *testing.T) {
 
 	m := cl.Inflight.GetAll()
 	require.Equal(t, 1, m[11].Resends) // index is packet id
+
+	// Expect a test persistence error.
+	require.Equal(t, "storage: test", hook.err.Error())
 }
 
 func TestServerResendClientInflightNoMessages(t *testing.T) {


### PR DESCRIPTION
Redo of #34.
Fixes #33.
Fixes #21.
Incorporates #36. 

Adds an OnError handler for errors that are not reported via the OnDisconnect handler.

Results from auditing error propagation in the server.
- an error was being skipped from ResendInflight
- an error was being ignored in `Reader.ReadFrom()`, which wasn't causing harm but made diagnosing other issues (and test coverage) more difficult

Adds a "Session reestablished" error to indicate when one client connection causes another to disconnect. For example, when two clients use the same ID, the server logs might read:

```
<< OnConnect client connected operator from [::1]:56779
<< OnDisconnect client disconnected operator connection from [::1]:56779: Session reestablished
```

Extends a few existing tests to hit test coverage.  Extensive testing reveals no new issues.