### PR TITLE
docker: add initial simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.18.0-alpine3.15 AS builder
+
+RUN apk update
+RUN apk add git
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+COPY . ./
+
+RUN go build -o /app/mochi ./cmd
+
+
+FROM alpine
+
+WORKDIR /
+COPY --from=builder /app/mochi .
+
+# tcp
+EXPOSE 1883
+
+# websockets
+EXPOSE 1882
+
+# dashboard
+EXPOSE 8080
+
+ENTRYPOINT [ "/mochi" ]


### PR DESCRIPTION
This PR adds a very basic Dockerfile base on Alpine and Go 1.18

To use it, first 

```
docker build -t mochi:latest .
```

Then to run it with TCP, Websocket, and also HTTP dashboard available on the host:

```
docker run -p 1883:1883 -p 1882:1882 -p 8080:8080 mochi:latest
```