### PR TITLE
hotfix - system.info is not set correct back to listeners

### DIFF
--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/logrusorgru/aurora"
+
+	mqtt "github.com/mochi-co/mqtt/server"
+	"github.com/mochi-co/mqtt/server/listeners"
+)
+
+func main() {
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		done <- true
+	}()
+
+	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("TCP"))
+
+	server := mqtt.NewServer(nil)
+	tcp := listeners.NewTCP("t1", ":1883")
+	err := server.AddListener(tcp, &listeners.Config{
+		Auth: &Auth{
+			Users: map[string]string{
+				"peach": "password1",
+				"melon": "password2",
+				"apple": "password3",
+			},
+			AllowedTopics: map[string][]string{
+				// Melon user only has access to melon topics.
+				// If you were implementing this in the real world, you might ensure
+				// that any topic prefixed with "melon" is allowed (see ACL func below).
+				"melon": {"melon/info", "melon/events"},
+			},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		err := server.Serve()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
+	fmt.Println(aurora.BgMagenta("  Started!  "))
+
+	<-done
+	fmt.Println(aurora.BgRed("  Caught Signal  "))
+
+	server.Close()
+	fmt.Println(aurora.BgGreen("  Finished  "))
+}
+
+// Auth is an example auth provider for the server. In the real world
+// you are more likely to replace these fields with database/cache lookups
+// to check against an auth list. As the Auth Controller is an interface, it can
+// be built however you want, as long as it fulfils the interface signature.
+type Auth struct {
+	Users         map[string]string   // A map of usernames (key) with passwords (value).
+	AllowedTopics map[string][]string // A map of usernames and topics
+}
+
+// Authenticate returns true if a username and password are acceptable.
+// Auth always returns true.
+func (a *Auth) Authenticate(user, password []byte) bool {
+	// If the user exists in the auth users map, and the password is correct,
+	// then they can connect to the server.
+	if pass, ok := a.Users[string(user)]; ok && pass == string(password) {
+		return true
+	}
+
+	return false
+}
+
+// ACL returns true if a user has access permissions to read or write on a topic.
+func (a *Auth) ACL(user []byte, topic string, write bool) bool {
+
+	// An example ACL - if the user has an entry in the auth allow list, then they are
+	// subject to ACL restrictions. Only let them use a topic if it's available for their
+	// user.
+	if topics, ok := a.AllowedTopics[string(user)]; ok {
+		for _, t := range topics {
+
+			// In the real world you might allow all topics prefixed with a user's username,
+			// or similar multi-topic filters.
+			if t == topic {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// Otherwise, allow all topics.
+	return true
+}

--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -70,10 +70,10 @@ type Auth struct {
 }
 
 // Authenticate returns true if a username and password are acceptable.
-// Auth always returns true.
 func (a *Auth) Authenticate(user, password []byte) bool {
 	// If the user exists in the auth users map, and the password is correct,
-	// then they can connect to the server.
+	// then they can connect to the server. In the real world, this could be a database
+	// or cached users lookup.
 	if pass, ok := a.Users[string(user)]; ok && pass == string(password) {
 		return true
 	}

--- a/server/listeners/http_sysinfo.go
+++ b/server/listeners/http_sysinfo.go
@@ -61,6 +61,10 @@ func (l *HTTPStats) ID() string {
 }
 
 // Listen starts listening on the listener's network address.
+func (l *HTTPStats) SetSystemStat(s *system.Info) {
+	l.system = s
+}
+
 func (l *HTTPStats) Listen(s *system.Info) error {
 	l.system = s
 	mux := http.NewServeMux()

--- a/server/listeners/listeners.go
+++ b/server/listeners/listeners.go
@@ -34,6 +34,7 @@ type Listener interface {
 	Serve(EstablishFunc)         // starting actively listening for new connections.
 	ID() string                  // return the id of the listener.
 	Close(CloseFunc)             // stop and close the listener.
+	SetSystemStat(s *system.Info)
 }
 
 // Listeners contains the network listeners for the broker.
@@ -117,6 +118,23 @@ func (l *Listeners) Close(id string, closer CloseFunc) {
 	listener := l.internal[id]
 	l.RUnlock()
 	listener.Close(closer)
+}
+
+// SetSystemStat call all listeners and set new server Info reference
+func (l *Listeners) SetSystemStat(s *system.Info) {
+	l.RLock()
+	i := 0
+	ids := make([]string, len(l.internal))
+	for id := range l.internal {
+		ids[i] = id
+		i++
+	}
+	l.RUnlock()
+
+	for _, id := range ids {
+		listener := l.internal[id]
+		listener.SetSystemStat(s)
+	}
 }
 
 // CloseAll iterates and closes all registered listeners.

--- a/server/listeners/mock.go
+++ b/server/listeners/mock.go
@@ -30,6 +30,14 @@ type MockListener struct {
 	ErrListen bool      // throw an error on listen.
 }
 
+func (l *MockListener) SetSystemStat(s *system.Info) {
+	//TODO implement me
+	if s == nil {
+		panic("implement me")
+	}
+
+}
+
 // NewMockListener returns a new instance of MockListener
 func NewMockListener(id, address string) *MockListener {
 	return &MockListener{

--- a/server/listeners/tcp.go
+++ b/server/listeners/tcp.go
@@ -34,6 +34,10 @@ func NewTCP(id, address string) *TCP {
 	}
 }
 
+func (l *TCP) SetSystemStat(s *system.Info) {
+
+}
+
 // SetConfig sets the configuration values for the listener config.
 func (l *TCP) SetConfig(config *Config) {
 	l.Lock()

--- a/server/listeners/websocket.go
+++ b/server/listeners/websocket.go
@@ -89,6 +89,10 @@ func NewWebsocket(id, address string) *Websocket {
 	}
 }
 
+func (l *Websocket) SetSystemStat(s *system.Info) {
+
+}
+
 // SetConfig sets the configuration values for the listener config.
 func (l *Websocket) SetConfig(config *Config) {
 	l.Lock()

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"sync/atomic"

--- a/server/server.go
+++ b/server/server.go
@@ -645,19 +645,14 @@ func (s *Server) publishToSubscribers(pk packets.Packet) {
 				}
 
 				if s.Store != nil {
-<<<<<<< HEAD
-					s.onStorage(client, s.Store.WriteInflight(persistence.Message{
-						ID:          persistentID(client, out),
-=======
 					s.Store.WriteInflight(persistence.Message{
 						ID:          "if_" + client.ID + "_" + strconv.Itoa(int(out.PacketID)),
->>>>>>> origin/master
 						T:           persistence.KInflight,
 						FixedHeader: persistence.FixedHeader(out.FixedHeader),
 						TopicName:   out.TopicName,
 						Payload:     out.Payload,
 						Sent:        sent,
-					}))
+					})
 				}
 			}
 
@@ -909,20 +904,15 @@ func (s *Server) ResendClientInflight(cl *clients.Client, force bool) error {
 		}
 
 		if s.Store != nil {
-<<<<<<< HEAD
-			s.onStorage(cl, s.Store.WriteInflight(persistence.Message{
-				ID:          persistentID(cl, tk.Packet),
-=======
 			s.Store.WriteInflight(persistence.Message{
 				ID:          "if_" + cl.ID + "_" + strconv.Itoa(int(tk.Packet.PacketID)),
->>>>>>> origin/master
 				T:           persistence.KInflight,
 				FixedHeader: persistence.FixedHeader(tk.Packet.FixedHeader),
 				TopicName:   tk.Packet.TopicName,
 				Payload:     tk.Packet.Payload,
 				Sent:        tk.Sent,
 				Resends:     tk.Resends,
-			}))
+			})
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -999,6 +999,7 @@ func (s *Server) loadServerInfo(v persistence.ServerInfo) {
 	version := s.System.Version
 	s.System = &v.Info
 	s.System.Version = version
+	s.Listeners.SetSystemStat(s.System)
 }
 
 // loadSubscriptions restores subscriptions from the datastore.

--- a/server/server.go
+++ b/server/server.go
@@ -4,7 +4,6 @@ package server
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"strconv"
 	"sync/atomic"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2558,6 +2558,7 @@ func TestServerResendClientInflightBackoff(t *testing.T) {
 	mock.Fail["write_inflight"] = true
 
 	var hook errorHook
+	hook.err = errors.New("storage: test")
 	s.Events.OnError = hook.onError
 
 	r, w := net.Pipe()
@@ -2589,6 +2590,7 @@ func TestServerResendClientInflightBackoff(t *testing.T) {
 	})
 
 	err := s.ResendClientInflight(cl, true)
+	m := cl.Inflight.GetAll()
 	require.NoError(t, err)
 
 	time.Sleep(time.Millisecond)
@@ -2608,7 +2610,7 @@ func TestServerResendClientInflightBackoff(t *testing.T) {
 		'h', 'e', 'l', 'l', 'o',
 	}, rcv)
 
-	m := cl.Inflight.GetAll()
+	m = cl.Inflight.GetAll()
 	require.Equal(t, 1, m[11].Resends) // index is packet id
 
 	// Expect a test persistence error.


### PR DESCRIPTION
fix the issue with httpStat server, missing stats if you use BOLTDB
- added SetSystemStat(s *system.Info) to Listener Interface