### PR TITLE
Configurable Server Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,26 @@ server.Events.OnMessage = func(cl events.Client, pk events.Packet) (pkx events.P
 
 The OnMessage hook can also be used to selectively only deliver messages to one or more clients based on their id, using the `AllowClients []string` field on the packet structure.  
 
+#### Server Options
+A few options can be passed to the `mqtt.NewServer(opts *Options)` function in order to override the default broker configuration. Currently these options are:
+
+
+- BufferSize (default 1024 * 256 bytes) - The default value is sufficient for most messaging sizes, but if you are sending many kilobytes of data (such as images), you should increase this to a value of (n*s) where is the typical size of your message and n is the number of messages you may have backlogged for a client at any given time.
+- BufferBlockSize (default 1024 * 8) - The minimum size in which R/W data will be allocated. If you are expecting only tiny or large payloads, you can alter this accordingly.
+
+Any options which is not set or is `0` will use default values.
+
+```go
+opts := &mqtt.Options{
+		BufferSize:      512 * 1024,
+		BufferBlockSize: 16 * 1024,
+}
+
+s := mqtt.NewServer(opts)
+
+```
+
+> See `examples/tcp/main.go` for an example implementation.
 
 #### Direct Publishing
 When the broker is being embedded in a larger codebase, it can be useful to be able to publish messages directly to clients without having to implement a loopback TCP connection with an MQTT client. The `Publish` method allows you to inject publish messages directly into a queue to be delivered to any clients with matching topic filters. The `Retain` flag is supported.

--- a/README.md
+++ b/README.md
@@ -166,12 +166,11 @@ Any options which is not set or is `0` will use default values.
 
 ```go
 opts := &mqtt.Options{
-		BufferSize:      512 * 1024,
-		BufferBlockSize: 16 * 1024,
+    BufferSize:      512 * 1024,
+    BufferBlockSize: 16 * 1024,
 }
 
 s := mqtt.NewServer(opts)
-
 ```
 
 > See `examples/tcp/main.go` for an example implementation.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,7 @@ func main() {
 	fmt.Println(aurora.Cyan("Websocket"), *wsAddr)
 	fmt.Println(aurora.Cyan("$SYS Dashboard"), *infoAddr)
 
-	server := mqtt.New()
+	server := mqtt.NewServer(nil)
 	tcp := listeners.NewTCP("t1", *tcpAddr)
 	err := server.AddListener(tcp, nil)
 	if err != nil {

--- a/examples/dashboard/main.go
+++ b/examples/dashboard/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("TCP"))
 
-	server := mqtt.New()
+	server := mqtt.NewServer(nil)
 
 	stats := listeners.NewHTTPStats("stats", ":8080")
 	err := server.AddListener(stats, nil)

--- a/examples/events/main.go
+++ b/examples/events/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("TCP"))
 
-	server := mqtt.New()
+	server := mqtt.NewServer(nil)
 	tcp := listeners.NewTCP("t1", ":1883")
 	err := server.AddListener(tcp, &listeners.Config{
 		Auth: new(auth.Allow),

--- a/examples/persistence/main.go
+++ b/examples/persistence/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("Persistence"))
 
-	server := mqtt.New()
+	server := mqtt.NewServer(nil)
 	tcp := listeners.NewTCP("t1", ":1883")
 	err := server.AddListener(tcp, &listeners.Config{
 		Auth: new(auth.Allow),

--- a/examples/tcp/main.go
+++ b/examples/tcp/main.go
@@ -25,7 +25,13 @@ func main() {
 
 	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("TCP"))
 
-	server := mqtt.NewServer(nil)
+	// An example of configuring various server options...
+	options := &mqtt.Options{
+		BufferSize:      0, // Use default values
+		BufferBlockSize: 0, // Use default values
+	}
+
+	server := mqtt.NewServer(options)
 	tcp := listeners.NewTCP("t1", ":1883")
 	err := server.AddListener(tcp, &listeners.Config{
 		Auth: new(auth.Allow),

--- a/examples/tcp/main.go
+++ b/examples/tcp/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("TCP"))
 
-	server := mqtt.New()
+	server := mqtt.NewServer(nil)
 	tcp := listeners.NewTCP("t1", ":1883")
 	err := server.AddListener(tcp, &listeners.Config{
 		Auth: new(auth.Allow),

--- a/examples/tls/main.go
+++ b/examples/tls/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("TLS/SSL"))
 
-	server := mqtt.New()
+	server := mqtt.NewServer(nil)
 	tcp := listeners.NewTCP("t1", ":1883")
 	err := server.AddListener(tcp, &listeners.Config{
 		Auth: new(auth.Allow),

--- a/examples/websocket/main.go
+++ b/examples/websocket/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	fmt.Println(aurora.Magenta("Mochi MQTT Server initializing..."), aurora.Cyan("TCP"))
 
-	server := mqtt.New()
+	server := mqtt.NewServer(nil)
 	ws := listeners.NewWebsocket("ws1", ":1882")
 	err := server.AddListener(ws, nil)
 	if err != nil {

--- a/server/internal/circ/pool.go
+++ b/server/internal/circ/pool.go
@@ -11,6 +11,10 @@ type BytesPool struct {
 
 // NewBytesPool returns a sync.pool of []byte.
 func NewBytesPool(n int) *BytesPool {
+	if n == 0 {
+		n = DefaultBufferSize
+	}
+
 	return &BytesPool{
 		pool: &sync.Pool{
 			New: func() interface{} {

--- a/server/server.go
+++ b/server/server.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"strconv"
 	"sync/atomic"
 	"time"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/mochi-co/mqtt/server/events"
 	"github.com/mochi-co/mqtt/server/internal/circ"
 	"github.com/mochi-co/mqtt/server/internal/clients"
@@ -95,7 +93,6 @@ type inlineMessages struct {
 // This method has been deprecated and will be removed in a future release.
 // Please use NewServer instead.
 func New() *Server {
-	log.Println(aurora.Red("mqtt.New() has been deprecated and will be removed in a future release - please use mqtt.NewServer(opts *Options) instead!"))
 	return NewServer(nil)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -99,6 +99,33 @@ func BenchmarkNew(b *testing.B) {
 	}
 }
 
+func TestNewServer(t *testing.T) {
+	opts := &Options{
+		BufferSize:      1000,
+		BufferBlockSize: 100,
+	}
+	s := NewServer(opts)
+	require.NotNil(t, s)
+	require.NotNil(t, s.Listeners)
+	require.NotNil(t, s.Clients)
+	require.NotNil(t, s.Topics)
+	require.Nil(t, s.Store)
+	require.NotEmpty(t, s.System.Version)
+	require.Equal(t, true, s.System.Started > 0)
+	require.Equal(t, 1000, s.Options.BufferSize)
+	require.Equal(t, 100, s.Options.BufferBlockSize)
+}
+
+func BenchmarkNewServer(b *testing.B) {
+	opts := &Options{
+		BufferSize:      1000,
+		BufferBlockSize: 100,
+	}
+	for n := 0; n < b.N; n++ {
+		NewServer(opts)
+	}
+}
+
 func TestServerAddStore(t *testing.T) {
 	s := New()
 	require.NotNil(t, s)


### PR DESCRIPTION
As per our discussion on issue #54, this pull request provides the ability to pass a struct of server options to the new server in order to override certain configuration values. In particular, it allows the operator to increase (or decrease) the size of the buffer and block used in the circular buffer for each client. This is necessary in systems where larger message payloads would otherwise be dropped due to over-running the buffer.

Key changes:
- A new `NewServer(opts *Options) *Server` function has been added to `server.go`, which allows the instantiation of a server with options. The original `New() *Server` function should be deprecated.
    - __Discussion:__ Alternatively, A) we introduce a breaking change and add the `opts *Options` parameter directly to the existing `New` function. Or B), `NewServer` should be renamed to `NewWithOptions` and the former `New` should not be deprecated. Insights wanted!
- Example files have been updated to use the new `NewServer` function.
- The Readme has been updated to include details about the new Options available.
- A minor change was made to `circ.Pool` to ensure it resolved the package Default rather than relying on it being passed externally.

I can't seem to add any reviewers to this PR, but FAO @jmacd, @deadprogram, @stffabi