### PR TITLE
Fix Inflight Persistence Key

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -565,7 +565,7 @@ func (s *Server) publishToSubscribers(pk packets.Packet) {
 				if s.Store != nil {
 					s.onStorage(client, s.Store.WriteInflight(persistence.Message{
 						ID:          persistentID(client, out),
-						T:           persistence.KRetained,
+						T:           persistence.KInflight,
 						FixedHeader: persistence.FixedHeader(out.FixedHeader),
 						TopicName:   out.TopicName,
 						Payload:     out.Payload,
@@ -824,7 +824,7 @@ func (s *Server) ResendClientInflight(cl *clients.Client, force bool) error {
 		if s.Store != nil {
 			s.onStorage(cl, s.Store.WriteInflight(persistence.Message{
 				ID:          persistentID(cl, tk.Packet),
-				T:           persistence.KRetained,
+				T:           persistence.KInflight,
 				FixedHeader: persistence.FixedHeader(tk.Packet.FixedHeader),
 				TopicName:   tk.Packet.TopicName,
 				Payload:     tk.Packet.Payload,


### PR DESCRIPTION
As per #59 - in two places in `server.go`, the `persistence.KRetained` key was used when it should be the `persistence.KInflight` key.

This PR resolves #59.