### PR TITLE
Add ErrRejectPacket to OnProcessMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,18 @@ server.Events.OnDisconnect = func(cl events.Client, err error) {
 ```
 
 ##### OnMessage
-`server.Events.OnMessage` is called when a Publish packet is received. The method receives the published message and information about the client who published it. 
+`server.Events.OnMessage` is called when a Publish packet (message) is received. The method receives the published message and information about the client who published it. 
 
 > This hook is only triggered when a message is received by clients. It is not triggered when using the direct `server.Publish` method.
+
+
+##### OnProcessMessage
+`server.Events.OnMessage` is called before a publish packet (message) is processed. Specifically, the method callback is triggered after topic and ACL validation has occurred, but before the headers and payload are processed. You can use this if you want to programmatically change the data of the packet, such as setting it to retain, or altering the QoS flag. 
+
+If an error is returned, the packet will not be modified. and the existing packet will be used. If this is an unwanted outcome, the `mqtt.ErrRejectPacket` error can be returned from the callback, and the packet will be dropped/ignored, any further processing is abandoned.
+
+> This hook is only triggered when a message is received by clients. It is not triggered when using the direct `server.Publish` method.
+
 
 ```go
 import "github.com/mochi-co/mqtt/server/events"

--- a/server/events/events.go
+++ b/server/events/events.go
@@ -29,17 +29,19 @@ type Clientlike interface {
 	Info() Client
 }
 
-// OnProcessMessage function is called right after a publish message is received.
-// It is called right after ACL checking and before any other data gets evaluated
-// for publishing. So this event e.g. allows changing the Retain flag. Note,
-// this hook is ONLY called by connected client publishers, it is not triggered when
-// using the direct s.Publish method. The function receives the sent message and the
+// OnProcessMessage is called when a publish message is received, allowing modification
+// of the packet data after ACL checking has occurred but before any data is evaluated
+// for processing - e.g. for changing the Retain flag. Note, this hook is ONLY called
+// by connected client publishers, it is not triggered when using the direct
+// s.Publish method. The function receives the sent message and the
 // data of the client who published it, and allows the packet to be modified
 // before it is dispatched to subscribers. If no modification is required, return
 // the original packet data. If an error occurs, the original packet will
 // be dispatched as if the event hook had not been triggered.
 // This function will block message dispatching until it returns. To minimise this,
 // have the function open a new goroutine on the embedding side.
+// The `mqtt.ErrRejectPacket` error can be returned to reject and abandon any futher
+// processing of the packet.
 type OnProcessMessage func(Client, Packet) (Packet, error)
 
 // OnMessage function is called when a publish message is received. Note,

--- a/server/server.go
+++ b/server/server.go
@@ -484,7 +484,9 @@ func (s *Server) processPublish(cl *clients.Client, pk packets.Packet) error {
 				return nil
 			}
 
-			s.Events.OnError(cl.Info(), err)
+			if s.Events.OnError != nil {
+				s.Events.OnError(cl.Info(), err)
+			}
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -41,6 +41,9 @@ var (
 	// ErrInvalidTopic indicates that the specified topic was not valid.
 	ErrInvalidTopic = errors.New("cannot publish to $ and $SYS topics")
 
+	// ErrRejectPacket indicates that a packet should be dropped instead of processed.
+	ErrRejectPacket = errors.New("packet rejected")
+
 	ErrClientDisconnect     = errors.New("Client disconnected")
 	ErrClientReconnect      = errors.New("Client attemped to reconnect")
 	ErrServerShutdown       = errors.New("Server is shutting down")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1521,6 +1521,9 @@ func TestServerProcessPublishHookOnProcessMessageModifyError(t *testing.T) {
 	s.Clients.Add(cl1)
 	s.Topics.Subscribe("a/b/+", cl1.ID, 0)
 
+	var hook errorHook
+	s.Events.OnError = hook.onError
+
 	s.Events.OnProcessMessage = func(cl events.Client, pk events.Packet) (events.Packet, error) {
 		pkx := pk
 		pkx.Payload = []byte("world")
@@ -1570,6 +1573,9 @@ func TestServerProcessPublishHookOnProcessMessageModifyError(t *testing.T) {
 	}, <-ack1)
 
 	require.Equal(t, int64(14), s.System.BytesSent)
+
+	require.Equal(t, 1, hook.cnt)
+	require.Equal(t, fmt.Errorf("error"), hook.err)
 }
 
 func TestServerProcessPuback(t *testing.T) {


### PR DESCRIPTION
As per our discussions in https://github.com/mochi-co/mqtt/pull/53#pullrequestreview-917410043, this pull request adds the ability to Reject a packet from the `onProcessMessage` event hook. 

- Adds the ErrRejectPacket error. When returned from an `onProcessMessage` callback, the packet processing will be abandoned.
- Add optional error logging for `OnProcessMessage` using the `OnError` event, if one is set.
- Updates tests to ensure rejected packets are properly abandoned.
- Updates Readme and Events documentation to describe the usage of ErrRejectPacket.

FAQ @jmacd, @stffabi