### PR TITLE
Release client buffers

### DIFF
--- a/server/internal/circ/pool_test.go
+++ b/server/internal/circ/pool_test.go
@@ -22,6 +22,7 @@ func TestNewBytesPoolGet(t *testing.T) {
 	buf := bpool.Get()
 
 	require.Equal(t, make([]byte, 256), buf)
+	require.Equal(t, int64(1), bpool.InUse())
 }
 
 func BenchmarkBytesPoolGet(b *testing.B) {
@@ -34,7 +35,9 @@ func BenchmarkBytesPoolGet(b *testing.B) {
 func TestNewBytesPoolPut(t *testing.T) {
 	bpool := NewBytesPool(256)
 	buf := bpool.Get()
+	require.Equal(t, int64(1), bpool.InUse())
 	bpool.Put(buf)
+	require.Equal(t, int64(0), bpool.InUse())
 }
 
 func BenchmarkBytesPoolPut(b *testing.B) {

--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -193,12 +193,6 @@ func (cl *Client) refreshDeadline(keepalive uint16) {
 	}
 }
 
-// // ReadBufferClear returns true if the read buffer is nil.
-// // This is almost exclusively to be used with unit tests, there's no real
-// func (cl *Client) BuffersClear() (bool, bool) {
-// 	return (cl.r == nil), (cl.w == nil)
-// }
-
 func (cl *Client) Info() events.Client {
 	addr := "unknown"
 	if cl.conn != nil && cl.conn.RemoteAddr() != nil {

--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -193,6 +193,7 @@ func (cl *Client) refreshDeadline(keepalive uint16) {
 	}
 }
 
+// Info returns an event-version of a client, containing minimal information.
 func (cl *Client) Info() events.Client {
 	addr := "unknown"
 	if cl.conn != nil && cl.conn.RemoteAddr() != nil {

--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -102,7 +102,7 @@ type Client struct {
 	systemInfo    *system.Info         // pointers to server system info.
 	packetID      uint32               // the current highest packetID.
 	keepalive     uint16               // the number of seconds the connection can wait.
-	cleanSession  bool                 // indicates if the client expects a clean-session.
+	CleanSession  bool                 // indicates if the client expects a clean-session.
 }
 
 // State tracks the state of the client.
@@ -167,7 +167,7 @@ func (cl *Client) Identify(lid string, pk packets.Packet, ac auth.Controller) {
 	cl.W.ID = cl.ID + " WRITER"
 
 	cl.Username = pk.Username
-	cl.cleanSession = pk.CleanSession
+	cl.CleanSession = pk.CleanSession
 	cl.keepalive = pk.Keepalive
 
 	if pk.WillFlag {

--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -96,8 +96,8 @@ type Client struct {
 	Listener      string               // the id of the listener the client is connected to.
 	ID            string               // the client id.
 	conn          net.Conn             // the net.Conn used to establish the connection.
-	r             *circ.Reader         // a reader for reading incoming bytes.
-	w             *circ.Writer         // a writer for writing outgoing bytes.
+	R             *circ.Reader         // a reader for reading incoming bytes.
+	W             *circ.Writer         // a writer for writing outgoing bytes.
 	Subscriptions topics.Subscriptions // a map of the subscription filters a client maintains.
 	systemInfo    *system.Info         // pointers to server system info.
 	packetID      uint32               // the current highest packetID.
@@ -119,8 +119,8 @@ type State struct {
 func NewClient(c net.Conn, r *circ.Reader, w *circ.Writer, s *system.Info) *Client {
 	cl := &Client{
 		conn:       c,
-		r:          r,
-		w:          w,
+		R:          r,
+		W:          w,
 		systemInfo: s,
 		keepalive:  defaultKeepalive,
 		Inflight: &Inflight{
@@ -163,8 +163,8 @@ func (cl *Client) Identify(lid string, pk packets.Packet, ac auth.Controller) {
 		cl.ID = xid.New().String()
 	}
 
-	cl.r.ID = cl.ID + " READER"
-	cl.w.ID = cl.ID + " WRITER"
+	cl.R.ID = cl.ID + " READER"
+	cl.W.ID = cl.ID + " WRITER"
 
 	cl.Username = pk.Username
 	cl.cleanSession = pk.CleanSession
@@ -192,6 +192,12 @@ func (cl *Client) refreshDeadline(keepalive uint16) {
 		_ = cl.conn.SetDeadline(expiry)
 	}
 }
+
+// // ReadBufferClear returns true if the read buffer is nil.
+// // This is almost exclusively to be used with unit tests, there's no real
+// func (cl *Client) BuffersClear() (bool, bool) {
+// 	return (cl.r == nil), (cl.w == nil)
+// }
 
 func (cl *Client) Info() events.Client {
 	addr := "unknown"
@@ -239,7 +245,7 @@ func (cl *Client) Start() {
 
 	go func() {
 		cl.State.started.Done()
-		_, err := cl.w.WriteTo(cl.conn)
+		_, err := cl.W.WriteTo(cl.conn)
 		if err != nil {
 			err = fmt.Errorf("writer: %w", err)
 		}
@@ -249,7 +255,7 @@ func (cl *Client) Start() {
 
 	go func() {
 		cl.State.started.Done()
-		_, err := cl.r.ReadFrom(cl.conn)
+		_, err := cl.R.ReadFrom(cl.conn)
 		if err != nil {
 			err = fmt.Errorf("reader: %w", err)
 		}
@@ -263,8 +269,8 @@ func (cl *Client) Start() {
 // ClearBuffers sets the read/write buffers to nil so they can be
 // deallocated automatically when no longer in use.
 func (cl *Client) ClearBuffers() {
-	cl.r = nil
-	cl.w = nil
+	cl.R = nil
+	cl.W = nil
 }
 
 // Stop instructs the client to shut down all processing goroutines and disconnect.
@@ -275,8 +281,8 @@ func (cl *Client) Stop(err error) {
 	}
 
 	cl.State.endOnce.Do(func() {
-		cl.r.Stop()
-		cl.w.Stop()
+		cl.R.Stop()
+		cl.W.Stop()
 
 		cl.State.endedW.Wait()
 
@@ -302,7 +308,7 @@ func (cl *Client) StopCause() error {
 
 // ReadFixedHeader reads in the values of the next packet's fixed header.
 func (cl *Client) ReadFixedHeader(fh *packets.FixedHeader) error {
-	p, err := cl.r.Read(1)
+	p, err := cl.R.Read(1)
 	if err != nil {
 		return err
 	}
@@ -319,7 +325,7 @@ func (cl *Client) ReadFixedHeader(fh *packets.FixedHeader) error {
 	i := 1
 	n := 2
 	for ; n < 6; n++ {
-		p, err = cl.r.Read(n)
+		p, err = cl.R.Read(n)
 		if err != nil {
 			return err
 		}
@@ -343,7 +349,7 @@ func (cl *Client) ReadFixedHeader(fh *packets.FixedHeader) error {
 	fh.Remaining = int(rem)
 
 	// Having successfully read n bytes, commit the tail forward.
-	cl.r.CommitTail(n)
+	cl.R.CommitTail(n)
 	atomic.AddInt64(&cl.systemInfo.BytesRecv, int64(n))
 
 	return nil
@@ -353,7 +359,7 @@ func (cl *Client) ReadFixedHeader(fh *packets.FixedHeader) error {
 // an error is encountered (or the connection is closed).
 func (cl *Client) Read(packetHandler func(*Client, packets.Packet) error) error {
 	for {
-		if atomic.LoadUint32(&cl.State.Done) == 1 && cl.r.CapDelta() == 0 {
+		if atomic.LoadUint32(&cl.State.Done) == 1 && cl.R.CapDelta() == 0 {
 			return nil
 		}
 
@@ -385,7 +391,7 @@ func (cl *Client) ReadPacket(fh *packets.FixedHeader) (pk packets.Packet, err er
 		return
 	}
 
-	p, err := cl.r.Read(pk.FixedHeader.Remaining)
+	p, err := cl.R.Read(pk.FixedHeader.Remaining)
 	if err != nil {
 		return pk, err
 	}
@@ -428,7 +434,7 @@ func (cl *Client) ReadPacket(fh *packets.FixedHeader) (pk packets.Packet, err er
 		err = fmt.Errorf("No valid packet available; %v", pk.FixedHeader.Type)
 	}
 
-	cl.r.CommitTail(pk.FixedHeader.Remaining)
+	cl.R.CommitTail(pk.FixedHeader.Remaining)
 
 	return
 }
@@ -439,8 +445,8 @@ func (cl *Client) WritePacket(pk packets.Packet) (n int, err error) {
 		return 0, ErrConnectionClosed
 	}
 
-	cl.w.Mu.Lock()
-	defer cl.w.Mu.Unlock()
+	cl.W.Mu.Lock()
+	defer cl.W.Mu.Unlock()
 
 	buf := new(bytes.Buffer)
 	switch pk.FixedHeader.Type {
@@ -483,7 +489,7 @@ func (cl *Client) WritePacket(pk packets.Packet) (n int, err error) {
 	}
 
 	// Write the packet bytes to the client byte buffer.
-	n, err = cl.w.Write(buf.Bytes())
+	n, err = cl.W.Write(buf.Bytes())
 	if err != nil {
 		return
 	}

--- a/server/internal/clients/clients_test.go
+++ b/server/internal/clients/clients_test.go
@@ -492,6 +492,16 @@ func TestClientReadOK(t *testing.T) {
 
 }
 
+func TestClientClearBuffers(t *testing.T) {
+	cl := genClient()
+	cl.Start()
+	cl.Stop(testClientStop)
+	cl.ClearBuffers()
+
+	require.Nil(t, cl.w)
+	require.Nil(t, cl.r)
+}
+
 func TestClientReadDone(t *testing.T) {
 	cl := genClient()
 	cl.Start()

--- a/server/internal/clients/clients_test.go
+++ b/server/internal/clients/clients_test.go
@@ -133,8 +133,8 @@ func TestNewClient(t *testing.T) {
 	require.NotNil(t, cl)
 	require.NotNil(t, cl.Inflight.internal)
 	require.NotNil(t, cl.Subscriptions)
-	require.NotNil(t, cl.r)
-	require.NotNil(t, cl.w)
+	require.NotNil(t, cl.R)
+	require.NotNil(t, cl.W)
 	require.Nil(t, cl.StopCause())
 }
 
@@ -347,8 +347,8 @@ func TestClientStart(t *testing.T) {
 	cl.Start()
 	defer cl.Stop(testClientStop)
 	time.Sleep(time.Millisecond)
-	require.Equal(t, uint32(1), atomic.LoadUint32(&cl.r.State))
-	require.Equal(t, uint32(2), atomic.LoadUint32(&cl.w.State))
+	require.Equal(t, uint32(1), atomic.LoadUint32(&cl.R.State))
+	require.Equal(t, uint32(2), atomic.LoadUint32(&cl.W.State))
 }
 
 func BenchmarkClientStart(b *testing.B) {
@@ -365,15 +365,15 @@ func TestClientReadFixedHeader(t *testing.T) {
 	cl.Start()
 	defer cl.Stop(testClientStop)
 
-	cl.r.Set([]byte{packets.Connect << 4, 0x00}, 0, 2)
-	cl.r.SetPos(0, 2)
+	cl.R.Set([]byte{packets.Connect << 4, 0x00}, 0, 2)
+	cl.R.SetPos(0, 2)
 
 	fh := new(packets.FixedHeader)
 	err := cl.ReadFixedHeader(fh)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), atomic.LoadInt64(&cl.systemInfo.BytesRecv))
 
-	tail, head := cl.r.GetPos()
+	tail, head := cl.R.GetPos()
 	require.Equal(t, int64(2), tail)
 	require.Equal(t, int64(2), head)
 
@@ -387,8 +387,8 @@ func TestClientReadFixedHeaderDecodeError(t *testing.T) {
 	o := make(chan error)
 	go func() {
 		fh := new(packets.FixedHeader)
-		cl.r.Set([]byte{packets.Connect<<4 | 1<<1, 0x00, 0x00}, 0, 2)
-		cl.r.SetPos(0, 2)
+		cl.R.Set([]byte{packets.Connect<<4 | 1<<1, 0x00, 0x00}, 0, 2)
+		cl.R.SetPos(0, 2)
 		o <- cl.ReadFixedHeader(fh)
 	}()
 	time.Sleep(time.Millisecond)
@@ -403,12 +403,12 @@ func TestClientReadFixedHeaderReadEOF(t *testing.T) {
 	o := make(chan error)
 	go func() {
 		fh := new(packets.FixedHeader)
-		cl.r.Set([]byte{packets.Connect << 4, 0x00}, 0, 2)
-		cl.r.SetPos(0, 1)
+		cl.R.Set([]byte{packets.Connect << 4, 0x00}, 0, 2)
+		cl.R.SetPos(0, 1)
 		o <- cl.ReadFixedHeader(fh)
 	}()
 	time.Sleep(time.Millisecond)
-	cl.r.Stop()
+	cl.R.Stop()
 	err := <-o
 	require.Error(t, err)
 	require.Equal(t, io.EOF, err)
@@ -422,9 +422,9 @@ func TestClientReadFixedHeaderNoLengthTerminator(t *testing.T) {
 	o := make(chan error)
 	go func() {
 		fh := new(packets.FixedHeader)
-		err := cl.r.Set([]byte{packets.Connect << 4, 0xd5, 0x86, 0xf9, 0x9e, 0x01}, 0, 5)
+		err := cl.R.Set([]byte{packets.Connect << 4, 0xd5, 0x86, 0xf9, 0x9e, 0x01}, 0, 5)
 		require.NoError(t, err)
-		cl.r.SetPos(0, 5)
+		cl.R.SetPos(0, 5)
 		o <- cl.ReadFixedHeader(fh)
 	}()
 	time.Sleep(time.Millisecond)
@@ -448,9 +448,9 @@ func TestClientReadOK(t *testing.T) {
 		'y', 'e', 'a', 'h', // Payload
 	}
 
-	err := cl.r.Set(b, 0, len(b))
+	err := cl.R.Set(b, 0, len(b))
 	require.NoError(t, err)
-	cl.r.SetPos(0, int64(len(b)))
+	cl.R.SetPos(0, int64(len(b)))
 
 	o := make(chan error)
 	var pks []packets.Packet
@@ -462,7 +462,7 @@ func TestClientReadOK(t *testing.T) {
 	}()
 
 	time.Sleep(time.Millisecond)
-	cl.r.Stop()
+	cl.R.Stop()
 
 	err = <-o
 	require.Error(t, err)
@@ -498,8 +498,8 @@ func TestClientClearBuffers(t *testing.T) {
 	cl.Stop(testClientStop)
 	cl.ClearBuffers()
 
-	require.Nil(t, cl.w)
-	require.Nil(t, cl.r)
+	require.Nil(t, cl.W)
+	require.Nil(t, cl.R)
 }
 
 func TestClientReadDone(t *testing.T) {
@@ -526,9 +526,9 @@ func TestClientReadPacketError(t *testing.T) {
 		'a', '/', 'b', '/', 'c',
 		'h', 'e', 'l', 'l', 'o', ' ', 'm', 'o', 'c', 'h', 'i',
 	}
-	err := cl.r.Set(b, 0, len(b))
+	err := cl.R.Set(b, 0, len(b))
 	require.NoError(t, err)
-	cl.r.SetPos(0, int64(len(b)))
+	cl.R.SetPos(0, int64(len(b)))
 
 	o := make(chan error)
 	go func() {
@@ -550,9 +550,9 @@ func TestClientReadPacketEOF(t *testing.T) {
 		'a', '/', 'b', '/', 'c',
 		'h', 'e', 'l', 'l', 'o', ' ', 'm', 'o', 'c', 'h', // missing 1 byte
 	}
-	err := cl.r.Set(b, 0, len(b))
+	err := cl.R.Set(b, 0, len(b))
 	require.NoError(t, err)
-	cl.r.SetPos(0, int64(len(b)))
+	cl.R.SetPos(0, int64(len(b)))
 
 	o := make(chan error)
 	go func() {
@@ -561,7 +561,7 @@ func TestClientReadPacketEOF(t *testing.T) {
 		})
 	}()
 
-	cl.r.Stop()
+	cl.R.Stop()
 	cl.Stop(testClientStop)
 	require.Error(t, <-o)
 	require.True(t, errors.Is(cl.StopCause(), testClientStop))
@@ -579,9 +579,9 @@ func TestClientReadHandlerErr(t *testing.T) {
 		'y', 'e', 'a', 'h', // Payload
 	}
 
-	err := cl.r.Set(b, 0, len(b))
+	err := cl.R.Set(b, 0, len(b))
 	require.NoError(t, err)
-	cl.r.SetPos(0, int64(len(b)))
+	cl.R.SetPos(0, int64(len(b)))
 
 	err = cl.Read(func(cl *Client, pk packets.Packet) error {
 		return errors.New("test")
@@ -595,14 +595,14 @@ func TestClientReadPacketOK(t *testing.T) {
 	cl.Start()
 	defer cl.Stop(testClientStop)
 
-	err := cl.r.Set([]byte{
+	err := cl.R.Set([]byte{
 		byte(packets.Publish << 4), 11, // Fixed header
 		0, 5,
 		'd', '/', 'e', '/', 'f',
 		'y', 'e', 'a', 'h',
 	}, 0, 13)
 	require.NoError(t, err)
-	cl.r.SetPos(0, 13)
+	cl.R.SetPos(0, 13)
 
 	fh := new(packets.FixedHeader)
 	err = cl.ReadFixedHeader(fh)
@@ -628,9 +628,9 @@ func TestClientReadPacket(t *testing.T) {
 	defer cl.Stop(testClientStop)
 
 	for i, tt := range pkTable {
-		err := cl.r.Set(tt.bytes, 0, len(tt.bytes))
+		err := cl.R.Set(tt.bytes, 0, len(tt.bytes))
 		require.NoError(t, err)
-		cl.r.SetPos(0, int64(len(tt.bytes)))
+		cl.R.SetPos(0, int64(len(tt.bytes)))
 
 		fh := new(packets.FixedHeader)
 		err = cl.ReadFixedHeader(fh)
@@ -652,14 +652,14 @@ func TestClientReadPacketReadingError(t *testing.T) {
 	cl.Start()
 	defer cl.Stop(testClientStop)
 
-	err := cl.r.Set([]byte{
+	err := cl.R.Set([]byte{
 		0, 11, // Fixed header
 		0, 5,
 		'd', '/', 'e', '/', 'f',
 		'y', 'e', 'a', 'h',
 	}, 0, 13)
 	require.NoError(t, err)
-	cl.r.SetPos(2, 13)
+	cl.R.SetPos(2, 13)
 
 	_, err = cl.ReadPacket(&packets.FixedHeader{
 		Type:      0,
@@ -672,7 +672,7 @@ func TestClientReadPacketReadError(t *testing.T) {
 	cl := genClient()
 	cl.Start()
 	defer cl.Stop(testClientStop)
-	cl.r.Stop()
+	cl.R.Stop()
 
 	_, err := cl.ReadPacket(&packets.FixedHeader{
 		Remaining: 1,
@@ -685,7 +685,7 @@ func TestClientReadPacketReadUnknown(t *testing.T) {
 	cl := genClient()
 	cl.Start()
 	defer cl.Stop(testClientStop)
-	cl.r.Stop()
+	cl.R.Stop()
 
 	_, err := cl.ReadPacket(&packets.FixedHeader{
 		Remaining: 1,
@@ -719,6 +719,7 @@ func TestClientWritePacket(t *testing.T) {
 		// The stop cause is either the test error, EOF, or a
 		// closed pipe, depending on which goroutine runs first.
 		err = cl.StopCause()
+		time.Sleep(time.Millisecond * 5)
 		require.True(t,
 			errors.Is(err, testClientStop) ||
 				errors.Is(err, io.EOF) ||
@@ -735,7 +736,7 @@ func TestClientWritePacket(t *testing.T) {
 func TestClientWritePacketWriteNoConn(t *testing.T) {
 	c, _ := net.Pipe()
 	cl := NewClient(c, circ.NewReader(16, 4), circ.NewWriter(16, 4), new(system.Info))
-	cl.w.SetPos(0, 16)
+	cl.W.SetPos(0, 16)
 	cl.Stop(testClientStop)
 
 	_, err := cl.WritePacket(pkTable[1].packet)
@@ -746,8 +747,8 @@ func TestClientWritePacketWriteNoConn(t *testing.T) {
 func TestClientWritePacketWriteError(t *testing.T) {
 	c, _ := net.Pipe()
 	cl := NewClient(c, circ.NewReader(16, 4), circ.NewWriter(16, 4), new(system.Info))
-	cl.w.SetPos(0, 16)
-	cl.w.Stop()
+	cl.W.SetPos(0, 16)
+	cl.W.Stop()
 
 	_, err := cl.WritePacket(pkTable[1].packet)
 	require.Error(t, err)

--- a/server/internal/clients/clients_test.go
+++ b/server/internal/clients/clients_test.go
@@ -206,7 +206,7 @@ func TestClientIdentify(t *testing.T) {
 
 	cl.Identify("tcp1", pk, new(auth.Allow))
 	require.Equal(t, pk.Keepalive, cl.keepalive)
-	require.Equal(t, pk.CleanSession, cl.cleanSession)
+	require.Equal(t, pk.CleanSession, cl.CleanSession)
 	require.Equal(t, pk.ClientIdentifier, cl.ID)
 }
 

--- a/server/persistence/bolt/bolt.go
+++ b/server/persistence/bolt/bolt.go
@@ -1,7 +1,7 @@
 package bolt
 
 import (
-	"errors"
+	"fmt"
 	"time"
 
 	sgob "github.com/asdine/storm/codec/gob"
@@ -12,12 +12,17 @@ import (
 )
 
 const (
-	defaultPath    = "mochi.db"
+
+	// defaultPath is the default file to use to store the data.
+	defaultPath = "mochi.db"
+
+	// defaultTimeout is the default timeout of the file lock.
 	defaultTimeout = 250 * time.Millisecond
 )
 
 var (
-	errNotFound = "not found"
+	// ErrDBNotOpen indicates the bolt db file is not open for reading.
+	ErrDBNotOpen = fmt.Errorf("boltdb not opened")
 )
 
 // Store is a backend for writing and reading to bolt persistent storage.
@@ -64,7 +69,7 @@ func (s *Store) Close() {
 // WriteServerInfo writes the server info to the boltdb instance.
 func (s *Store) WriteServerInfo(v persistence.ServerInfo) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.Save(&v)
@@ -77,7 +82,7 @@ func (s *Store) WriteServerInfo(v persistence.ServerInfo) error {
 // WriteSubscription writes a single subscription to the boltdb instance.
 func (s *Store) WriteSubscription(v persistence.Subscription) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.Save(&v)
@@ -90,7 +95,7 @@ func (s *Store) WriteSubscription(v persistence.Subscription) error {
 // WriteInflight writes a single inflight message to the boltdb instance.
 func (s *Store) WriteInflight(v persistence.Message) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.Save(&v)
@@ -103,7 +108,7 @@ func (s *Store) WriteInflight(v persistence.Message) error {
 // WriteRetained writes a single retained message to the boltdb instance.
 func (s *Store) WriteRetained(v persistence.Message) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.Save(&v)
@@ -116,7 +121,7 @@ func (s *Store) WriteRetained(v persistence.Message) error {
 // WriteClient writes a single client to the boltdb instance.
 func (s *Store) WriteClient(v persistence.Client) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.Save(&v)
@@ -129,7 +134,7 @@ func (s *Store) WriteClient(v persistence.Client) error {
 // DeleteSubscription deletes a subscription from the boltdb instance.
 func (s *Store) DeleteSubscription(id string) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.DeleteStruct(&persistence.Subscription{
@@ -145,7 +150,7 @@ func (s *Store) DeleteSubscription(id string) error {
 // DeleteClient deletes a client from the boltdb instance.
 func (s *Store) DeleteClient(id string) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.DeleteStruct(&persistence.Client{
@@ -161,7 +166,7 @@ func (s *Store) DeleteClient(id string) error {
 // DeleteInflight deletes an inflight message from the boltdb instance.
 func (s *Store) DeleteInflight(id string) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.DeleteStruct(&persistence.Message{
@@ -177,7 +182,7 @@ func (s *Store) DeleteInflight(id string) error {
 // DeleteRetained deletes a retained message from the boltdb instance.
 func (s *Store) DeleteRetained(id string) error {
 	if s.db == nil {
-		return errors.New("boltdb not opened")
+		return ErrDBNotOpen
 	}
 
 	err := s.db.DeleteStruct(&persistence.Message{
@@ -193,11 +198,11 @@ func (s *Store) DeleteRetained(id string) error {
 // ReadSubscriptions loads all the subscriptions from the boltdb instance.
 func (s *Store) ReadSubscriptions() (v []persistence.Subscription, err error) {
 	if s.db == nil {
-		return v, errors.New("boltdb not opened")
+		return v, ErrDBNotOpen
 	}
 
 	err = s.db.Find("T", persistence.KSubscription, &v)
-	if err != nil && err.Error() != errNotFound {
+	if err != nil && err != storm.ErrNotFound {
 		return
 	}
 
@@ -207,11 +212,11 @@ func (s *Store) ReadSubscriptions() (v []persistence.Subscription, err error) {
 // ReadClients loads all the clients from the boltdb instance.
 func (s *Store) ReadClients() (v []persistence.Client, err error) {
 	if s.db == nil {
-		return v, errors.New("boltdb not opened")
+		return v, ErrDBNotOpen
 	}
 
 	err = s.db.Find("T", persistence.KClient, &v)
-	if err != nil && err.Error() != errNotFound {
+	if err != nil && err != storm.ErrNotFound {
 		return
 	}
 
@@ -221,11 +226,11 @@ func (s *Store) ReadClients() (v []persistence.Client, err error) {
 // ReadInflight loads all the inflight messages from the boltdb instance.
 func (s *Store) ReadInflight() (v []persistence.Message, err error) {
 	if s.db == nil {
-		return v, errors.New("boltdb not opened")
+		return v, ErrDBNotOpen
 	}
 
 	err = s.db.Find("T", persistence.KInflight, &v)
-	if err != nil && err.Error() != errNotFound {
+	if err != nil && err != storm.ErrNotFound {
 		return
 	}
 
@@ -235,11 +240,11 @@ func (s *Store) ReadInflight() (v []persistence.Message, err error) {
 // ReadRetained loads all the retained messages from the boltdb instance.
 func (s *Store) ReadRetained() (v []persistence.Message, err error) {
 	if s.db == nil {
-		return v, errors.New("boltdb not opened")
+		return v, ErrDBNotOpen
 	}
 
 	err = s.db.Find("T", persistence.KRetained, &v)
-	if err != nil && err.Error() != errNotFound {
+	if err != nil && err != storm.ErrNotFound {
 		return
 	}
 
@@ -249,11 +254,11 @@ func (s *Store) ReadRetained() (v []persistence.Message, err error) {
 //ReadServerInfo loads the server info from the boltdb instance.
 func (s *Store) ReadServerInfo() (v persistence.ServerInfo, err error) {
 	if s.db == nil {
-		return v, errors.New("boltdb not opened")
+		return v, ErrDBNotOpen
 	}
 
 	err = s.db.One("ID", persistence.KServerInfo, &v)
-	if err != nil && err.Error() != errNotFound {
+	if err != nil && err != storm.ErrNotFound {
 		return
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -281,8 +281,8 @@ func (s *Server) EstablishConnection(lid string, c net.Conn, ac auth.Controller)
 	)
 
 	cl.Start()
+	defer cl.ClearBuffers()
 	defer cl.Stop(nil)
-	// defer cl.ClearBuffers()
 
 	pk, err := s.readConnectionPacket(cl)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -34,8 +34,7 @@ var (
 	// ErrReadConnectInvalid indicates that the connection packet was invalid.
 	ErrReadConnectInvalid = errors.New("connect packet was not valid")
 
-	// ErrConnectNotAuthorized indicates that the connection packet had incorrect
-	// authentication parameters.
+	// ErrConnectNotAuthorized indicates that the connection packet had incorrect auth values.
 	ErrConnectNotAuthorized = errors.New("connect packet was not authorized")
 
 	// ErrInvalidTopic indicates that the specified topic was not valid.
@@ -44,11 +43,21 @@ var (
 	// ErrRejectPacket indicates that a packet should be dropped instead of processed.
 	ErrRejectPacket = errors.New("packet rejected")
 
-	ErrClientDisconnect     = errors.New("Client disconnected")
-	ErrClientReconnect      = errors.New("Client attemped to reconnect")
-	ErrServerShutdown       = errors.New("Server is shutting down")
-	ErrSessionReestablished = errors.New("Session reestablished")
-	ErrConnectionFailed     = errors.New("Connection attempt failed")
+	// ErrClientDisconnect indicates that a client disconnected from the server.
+	ErrClientDisconnect = errors.New("client disconnected")
+
+	// ErrClientReconnect indicates that a client attempted to reconnect while still connected.
+	ErrClientReconnect = errors.New("client sent connect while connected")
+
+	// ErrServerShutdown is propagated when the server shuts down.
+	ErrServerShutdown = errors.New("server is shutting down")
+
+	// ErrSessionReestablished indicates that an existing client was replaced by a newly connected
+	// client. The existing client is disconnected.
+	ErrSessionReestablished = errors.New("client session re-established")
+
+	// ErrConnectionFailed indicates that a client connection attempt failed for other reasons.
+	ErrConnectionFailed = errors.New("connection attempt failed")
 
 	// SysTopicInterval is the number of milliseconds between $SYS topic publishes.
 	SysTopicInterval time.Duration = 30000

--- a/server/server.go
+++ b/server/server.go
@@ -216,24 +216,25 @@ func (s *Server) inlineClient() {
 	}
 }
 
-// connSetup reads the first incoming header for a connection, and if
+// readConnectionPacket reads the first incoming header for a connection, and if
 // acceptable, returns the valid connection packet.
-func (s *Server) connSetup(cl *clients.Client) (packets.Packet, error) {
+func (s *Server) readConnectionPacket(cl *clients.Client) (pk packets.Packet, err error) {
 	fh := new(packets.FixedHeader)
-	if err := cl.ReadFixedHeader(fh); err != nil {
-		return packets.Packet{}, err
+	err = cl.ReadFixedHeader(fh)
+	if err != nil {
+		return
 	}
 
-	pk, err := cl.ReadPacket(fh)
+	pk, err = cl.ReadPacket(fh)
 	if err != nil {
-		return pk, err
+		return
 	}
 
 	if pk.FixedHeader.Type != packets.Connect {
 		return pk, ErrReadConnectInvalid
 	}
 
-	return pk, nil
+	return
 }
 
 // onError is a pass-through method which triggers the OnError

--- a/server/server.go
+++ b/server/server.go
@@ -374,7 +374,10 @@ func (s *Server) inheritClientSession(pk packets.Packet, cl *clients.Client) boo
 
 		existing.Stop(ErrSessionReestablished) // Issue a stop on the old client.
 
-		if pk.CleanSession {
+		// Per [MQTT-3.1.2-6]:
+		// If CleanSession is set to 1, the Client and Server MUST discard any previous Session and start a new one.
+		// The state associated with a CleanSession MUST NOT be reused in any subsequent session.
+		if pk.CleanSession || existing.CleanSession {
 			s.unsubscribeClient(existing)
 			return false
 		}
@@ -389,6 +392,16 @@ func (s *Server) inheritClientSession(pk packets.Packet, cl *clients.Client) boo
 			atomic.AddInt64(&s.System.ClientsMax, 1)
 		}
 		return false
+	}
+}
+
+// unsubscribeClient unsubscribes a client from all of their subscriptions.
+func (s *Server) unsubscribeClient(cl *clients.Client) {
+	for k := range cl.Subscriptions {
+		delete(cl.Subscriptions, k)
+		if s.Topics.Unsubscribe(k, cl.ID) {
+			atomic.AddInt64(&s.System.Subscriptions, -1)
+		}
 	}
 }
 
@@ -903,16 +916,6 @@ func (s *Server) ResendClientInflight(cl *clients.Client, force bool) error {
 	}
 
 	return nil
-}
-
-// unsubscribeClient unsubscribes a client from all of their subscriptions.
-func (s *Server) unsubscribeClient(cl *clients.Client) {
-	for k := range cl.Subscriptions {
-		delete(cl.Subscriptions, k)
-		if s.Topics.Unsubscribe(k, cl.ID) {
-			atomic.AddInt64(&s.System.Subscriptions, -1)
-		}
-	}
 }
 
 // Close attempts to gracefully shutdown the server, all listeners, clients, and stores.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -729,9 +729,7 @@ func TestServerEstablishConnectionInvalidProtocols(t *testing.T) {
 	err := s.EstablishConnection("tcp", r, new(auth.Allow))
 
 	r.Close()
-	time.Sleep(time.Millisecond * 100)
 	require.Error(t, err)
-	require.ErrorIs(t, err, packets.ErrProtocolViolation)
 
 	_, ok := s.Clients.Get("mochi")
 	require.False(t, ok)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -520,7 +520,7 @@ func TestServerEventOnDisconnectOnError(t *testing.T) {
 	require.Nil(t, clw.W)
 }
 
-func TestServerEstablishConnectionOKInheritSession(t *testing.T) {
+func TestServerEstablishConnectionInheritSession(t *testing.T) {
 	s := New()
 
 	c, _ := net.Pipe()
@@ -573,6 +573,68 @@ func TestServerEstablishConnectionOKInheritSession(t *testing.T) {
 	clw, ok := s.Clients.Get("mochi")
 	require.True(t, ok)
 	require.NotEmpty(t, clw.Subscriptions)
+
+	require.Equal(t, int64(0), s.bytepool.InUse())
+	require.Nil(t, clw.R)
+	require.Nil(t, clw.W)
+}
+
+func TestServerEstablishConnectionInheritExistingCleanSession(t *testing.T) {
+	s := New()
+
+	c, _ := net.Pipe()
+	cl := clients.NewClient(c, circ.NewReader(256, 8), circ.NewWriter(256, 8), s.System)
+	cl.ID = "mochi"
+	cl.CleanSession = true
+	cl.Subscriptions = map[string]byte{
+		"a/b/c": 1,
+	}
+	s.Clients.Add(cl)
+
+	r, w := net.Pipe()
+	o := make(chan error)
+	go func() {
+		o <- s.EstablishConnection("tcp", r, new(auth.Allow))
+	}()
+
+	go func() {
+		w.Write([]byte{
+			byte(packets.Connect << 4), 17, // Fixed header
+			0, 4, // Protocol Name - MSB+LSB
+			'M', 'Q', 'T', 'T', // Protocol Name
+			4,     // Protocol Version
+			0,     // Packet Flags
+			0, 45, // Keepalive
+			0, 5, // Client ID - MSB+LSB
+			'm', 'o', 'c', 'h', 'i', // Client ID
+		})
+		w.Write([]byte{byte(packets.Disconnect << 4), 0})
+	}()
+
+	// Receive the Connack
+	recv := make(chan []byte)
+	go func() {
+		buf, err := ioutil.ReadAll(w)
+		if err != nil {
+			panic(err)
+		}
+		recv <- buf
+	}()
+
+	errx := <-o
+	require.ErrorIs(t, errx, ErrClientDisconnect)
+	require.Equal(t, []byte{
+		byte(packets.Connack << 4),
+		2,
+		0, // no session present
+		packets.Accepted,
+	}, <-recv)
+
+	w.Close()
+
+	clw, ok := s.Clients.Get("mochi")
+	require.True(t, ok)
+	require.Empty(t, clw.Subscriptions)
 
 	require.Equal(t, int64(0), s.bytepool.InUse())
 	require.Nil(t, clw.R)
@@ -811,6 +873,8 @@ func TestServerEstablishConnectionClearBuffersAfterUse(t *testing.T) {
 	require.Equal(t, int64(0), s.bytepool.InUse()) // ensure the buffers have been returned to pool.
 	require.ErrorIs(t, errx, ErrClientDisconnect)
 	w.Close()
+
+	time.Sleep(time.Millisecond * 50)
 
 	clw, ok := s.Clients.Get("mochi")
 	require.True(t, ok)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -894,7 +894,6 @@ func TestServerEstablishConnectionClearBuffersAfterUse(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		require.Equal(t, int64(2), s.bytepool.InUse())
 		recv <- buf
 	}()
 
@@ -903,7 +902,7 @@ func TestServerEstablishConnectionClearBuffersAfterUse(t *testing.T) {
 	require.ErrorIs(t, errx, ErrClientDisconnect)
 	w.Close()
 
-	time.Sleep(time.Millisecond * 50)
+	time.Sleep(time.Millisecond * 100)
 
 	clw, ok := s.Clients.Get("mochi")
 	require.True(t, ok)


### PR DESCRIPTION
This PR resolves #52 and the [conversation contained within](https://github.com/mochi-co/mqtt/pull/52#discussion_r830854647), in which it was determined that in some cases, the `xbr` and `xbw` client buffers could be leaked because the pool blocks were neither being returned to the pool. This occurred in any scenario where the client did not cleanly disconnect. Furthermore nor were the client's `r` and `w` buffers were not being released when a client disconnected, preventing the garbage collector from freeing up the buffer space for each client. 

Specifically:

- The `EstablishConnection` method has been rebuilt. Where the buffers were previously released by direct calls, defer statements are now used.
- Where connection failures were handled by a single ack response, multiple logic branches may now return specific ack reponses (eg. for invalid packets, bad auth values). This allows us to return an ack without committing an invalid client to the server.
- Where the connection was previously halted at the end of the method, defer is now used to ensure it is always closed down, regardless of the disconnection reason.
- Where the buffers were previously left intact, a new `cl.ClearBuffers` is implemented with defer, ensuring that the buffers are set to `nil` following the client stop process. 
- Where the system stats counter was previously decremented at the end of the method, defer is now used to ensure the system stats correctly follow the client status, regardless of the disconnection reason.
- All Server EstablishConnection tests have been updated to assert the correct race-free release of buffers.

Additionally:
- Where a connecting client with bad authentication details could previously disconnect an existing client bearing the same ID, the ACK is now returned prior to committing the client to the server, and the connection is abandoned. This resolves #35
- Where a connecting client could previously inherit the state of an existing client who had a true `CleanSession` flag, a new client session is now returned as per  `[MQTT-3.1.2-6]`. This resolves #52
- The usage of the bytepool is now tracked and exposed using `s.bytepool.InUse()`. This is used within the connection tests to ensure the pool blocks are being correctly returned.
- Various clarifications and additional comments on var and function/method signatures.