### PR TITLE
Fix Store Retained Messages

### DIFF
--- a/server/internal/topics/trie_test.go
+++ b/server/internal/topics/trie_test.go
@@ -113,8 +113,10 @@ func TestRetainMessage(t *testing.T) {
 	require.Equal(t, pk2, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Message)
 	require.Contains(t, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Clients, "client-1")
 
-	q = index.RetainMessage(pk2) // already existing
-	require.Equal(t, int64(0), q)
+	// The same message already exists, but we're not doing a deep-copy check, so it's considered
+	// to be a new message.
+	q = index.RetainMessage(pk2)
+	require.Equal(t, int64(1), q)
 	require.NotNil(t, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"])
 	require.Equal(t, pk2, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Message)
 	require.Contains(t, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Clients, "client-1")
@@ -126,6 +128,14 @@ func TestRetainMessage(t *testing.T) {
 	require.NotNil(t, index.Root.Leaves["path"].Leaves["to"].Leaves["my"].Leaves["mqtt"])
 	require.Equal(t, pk, index.Root.Leaves["path"].Leaves["to"].Leaves["my"].Leaves["mqtt"].Message)
 	require.Equal(t, false, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Message.FixedHeader.Retain)
+
+	// Second Delete retained
+	q = index.RetainMessage(pk3)
+	require.Equal(t, int64(0), q)
+	require.NotNil(t, index.Root.Leaves["path"].Leaves["to"].Leaves["my"].Leaves["mqtt"])
+	require.Equal(t, pk, index.Root.Leaves["path"].Leaves["to"].Leaves["my"].Leaves["mqtt"].Message)
+	require.Equal(t, false, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Message.FixedHeader.Retain)
+
 }
 
 func BenchmarkRetainMessage(b *testing.B) {

--- a/server/server.go
+++ b/server/server.go
@@ -576,20 +576,21 @@ func (s *Server) processPublish(cl *clients.Client, pk packets.Packet) error {
 // adds the message to the store so it can be reloaded if necessary.
 func (s *Server) retainMessage(cl events.Clientlike, pk packets.Packet) {
 	out := pk.PublishCopy()
-	q := s.Topics.RetainMessage(out)
-	atomic.AddInt64(&s.System.Retained, q)
+	r := s.Topics.RetainMessage(out)
+	atomic.AddInt64(&s.System.Retained, r)
 
 	if s.Store != nil {
-		if q == 1 {
+		id := "ret_" + out.TopicName
+		if r == 1 {
 			s.onStorage(cl, s.Store.WriteRetained(persistence.Message{
-				ID:          "ret_" + out.TopicName,
+				ID:          id,
 				T:           persistence.KRetained,
 				FixedHeader: persistence.FixedHeader(out.FixedHeader),
 				TopicName:   out.TopicName,
 				Payload:     out.Payload,
 			}))
 		} else {
-			s.onStorage(cl, s.Store.DeleteRetained("ret_"+out.TopicName))
+			s.onStorage(cl, s.Store.DeleteRetained(id))
 		}
 	}
 }


### PR DESCRIPTION
Resolves issue #43 in which only the first retained messages would be stored. This was caused by the incorrect evaluation of the returned r-value which indicated whether or not the message had been persisted. Simplifying the logic for returning this value fixes the issue in persistent stores.