### PR TITLE
fix-panic

### DIFF
--- a/server/internal/circ/pool.go
+++ b/server/internal/circ/pool.go
@@ -7,8 +7,10 @@ import (
 
 // BytesPool is a pool of []byte.
 type BytesPool struct {
+	// int64/uint64 has to the first words in order
+	// to be 64-aligned on 32-bit architectures.
+	used int64 // access atomically
 	pool *sync.Pool
-	used int64
 }
 
 // NewBytesPool returns a sync.pool of []byte.


### PR DESCRIPTION
fixed runtime panic in `server/internal/circ/pool.go` occurring on 32-bits architectures caused by misalignment of `BytesPool` struct members.

https://github.com/golang/go/issues/36606#issue-551005857