### PR TITLE
Fix concurrent map iteration and map write

### DIFF
--- a/server/internal/clients/clients_test.go
+++ b/server/internal/clients/clients_test.go
@@ -69,7 +69,7 @@ func BenchmarkClientsGet(b *testing.B) {
 	}
 }
 
-func TestClientsGetAll(t *testing.T) {
+func TestClientsCopy(t *testing.T) {
 	cl := New()
 	cl.Add(&Client{ID: "t1"})
 	cl.Add(&Client{ID: "t2"})
@@ -82,11 +82,11 @@ func TestClientsGetAll(t *testing.T) {
 	require.Contains(t, cl.internal, "t4")
 	require.Contains(t, cl.internal, "t5")
 
-	clients := cl.GetAll()
+	clients := cl.Copy()
 	require.Len(t, clients, 5)
 }
 
-func BenchmarkClientsGetAll(b *testing.B) {
+func BenchmarkClientsCopy(b *testing.B) {
 	cl := New()
 	cl.Add(&Client{ID: "t1"})
 	cl.Add(&Client{ID: "t2"})
@@ -94,7 +94,7 @@ func BenchmarkClientsGetAll(b *testing.B) {
 	cl.Add(&Client{ID: "t4"})
 	cl.Add(&Client{ID: "t5"})
 	for n := 0; n < b.N; n++ {
-		clients := cl.GetAll()
+		clients := cl.Copy()
 		require.Len(b, clients, 5)
 	}
 }
@@ -832,18 +832,18 @@ func BenchmarkInflightGet(b *testing.B) {
 	}
 }
 
-func TestInflightGetAll(t *testing.T) {
+func TestInflightCopy(t *testing.T) {
 	cl := genClient()
 	cl.Inflight.Set(2, InflightMessage{})
 
-	m := cl.Inflight.GetAll()
+	m := cl.Inflight.Copy()
 	o := map[uint16]InflightMessage{
 		2: {},
 	}
 	require.Equal(t, o, m)
 }
 
-func BenchmarkInflightGetAll(b *testing.B) {
+func BenchmarkInflightCopy(b *testing.B) {
 	cl := genClient()
 	cl.Inflight.Set(2, InflightMessage{Packet: packets.Packet{}, Sent: 0})
 	for n := 0; n < b.N; n++ {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1209,7 +1209,7 @@ func TestServerProcessPublishOfflineQueuing(t *testing.T) {
 		0, 2,
 	}, <-ack1)
 
-	queued := cl2.Inflight.GetAll()
+	queued := cl2.Inflight.Copy()
 	require.Equal(t, 2, len(queued))
 	require.Equal(t, "qos1", queued[1].Packet.TopicName)
 	require.Equal(t, "qos2", queued[2].Packet.TopicName)
@@ -2571,7 +2571,7 @@ func TestServerResendClientInflight(t *testing.T) {
 		'h', 'e', 'l', 'l', 'o',
 	}, rcv)
 
-	m := cl.Inflight.GetAll()
+	m := cl.Inflight.Copy()
 	require.Equal(t, 1, m[11].Resends) // index is packet id
 }
 
@@ -2635,7 +2635,7 @@ func TestServerResendClientInflightBackoff(t *testing.T) {
 		'h', 'e', 'l', 'l', 'o',
 	}, rcv)
 
-	m := cl.Inflight.GetAll()
+	m := cl.Inflight.Copy()
 	require.Equal(t, 1, m[11].Resends) // index is packet id
 
 	// Expect a test persistence error.
@@ -2684,7 +2684,7 @@ func TestServerResendClientInflightDropMessage(t *testing.T) {
 	require.NoError(t, err)
 	r.Close()
 
-	m := cl.Inflight.GetAll()
+	m := cl.Inflight.Copy()
 	require.Equal(t, 0, len(m))
 	require.Equal(t, int64(1), atomic.LoadInt64(&s.System.PublishDropped))
 }
@@ -2736,9 +2736,9 @@ func TestServerClearExpiredInflights(t *testing.T) {
 	})
 	s.Clients.Add(cl)
 
-	require.Len(t, cl.Inflight.GetAll(), 4)
+	require.Len(t, cl.Inflight.Copy(), 4)
 	s.clearExpiredInflights(n)
-	require.Len(t, cl.Inflight.GetAll(), 2)
+	require.Len(t, cl.Inflight.Copy(), 2)
 	require.Equal(t, int64(-2), s.System.Inflight)
 }
 
@@ -2770,10 +2770,10 @@ func TestServerClearAbandonedInflights(t *testing.T) {
 	s.Clients.Add(cl)
 	s.Clients.Add(cl2)
 
-	require.Len(t, cl.Inflight.GetAll(), 2)
-	require.Len(t, cl2.Inflight.GetAll(), 2)
+	require.Len(t, cl.Inflight.Copy(), 2)
+	require.Len(t, cl2.Inflight.Copy(), 2)
 	s.clearAbandonedInflights(cl)
-	require.Len(t, cl.Inflight.GetAll(), 0)
-	require.Len(t, cl2.Inflight.GetAll(), 2)
+	require.Len(t, cl.Inflight.Copy(), 0)
+	require.Len(t, cl2.Inflight.Copy(), 2)
 	require.Equal(t, int64(-2), s.System.Inflight)
 }


### PR DESCRIPTION
PR #90 introduced a regression.

If a client uses QoS 2, it happens that the broker panics with `fatal error: concurrent map iteration and map write`

```
fatal error: concurrent map iteration and map write

goroutine 16 [running]:
github.com/mochi-co/mqtt/server.(*Server).ResendClientInflight(0x1400015c000, 0x140000007e0, 0x0)
        mochi-mqtt/server/server.go:912 +0xf0
github.com/mochi-co/mqtt/server.(*Server).resendPendingInflights(0x1400015c000)
        mochi-mqtt/server/server.go:1122 +0x6c
github.com/mochi-co/mqtt/server.(*Server).eventLoop(0x1400015c000)
        mochi-mqtt/server/server.go:220 +0xf4
created by github.com/mochi-co/mqtt/server.(*Server).Serve
        mochi-mqtt/server/server.go:199 +0x70
```

This is because the `GetAll` method returns the map itself, instead of a copy.
The lock in `GetAll` doesn't help, because the map is used outside when the lock is already released.

There are two ways to fix that.
Either we hold the lock while iteration over the map (see `ForEach`), and use `SetWithoutLocking` and `GetWithoutLocking` in the loop, or we iterate over a copy of the map (see `ForEachCopy`).

I wasn't sure which approach is better, because one solution needs to copy the map, and the other may have more lock contention.

With the fix in this PR, at least the code doesn't panic anymore.