### PR TITLE
Fix concurrent map access for clients and inflights causes data race 

### DIFF
--- a/server/internal/clients/clients.go
+++ b/server/internal/clients/clients.go
@@ -51,9 +51,13 @@ func (cl *Clients) Add(val *Client) {
 
 // GetAll returns all the clients.
 func (cl *Clients) GetAll() map[string]*Client {
+	m := map[string]*Client{}
 	cl.RLock()
 	defer cl.RUnlock()
-	return cl.internal
+	for k, v := range cl.internal {
+		m[k] = v
+	}
+	return m
 }
 
 // Get returns the value of a client if it exists.
@@ -435,7 +439,7 @@ func (cl *Client) ReadPacket(fh *packets.FixedHeader) (pk packets.Packet, err er
 	case packets.Pingresp:
 	case packets.Disconnect:
 	default:
-		err = fmt.Errorf("No valid packet available; %v", pk.FixedHeader.Type)
+		err = fmt.Errorf("no valid packet available; %v", pk.FixedHeader.Type)
 	}
 
 	cl.R.CommitTail(pk.FixedHeader.Remaining)
@@ -486,7 +490,7 @@ func (cl *Client) WritePacket(pk packets.Packet) (n int, err error) {
 	case packets.Disconnect:
 		err = pk.DisconnectEncode(buf)
 	default:
-		err = fmt.Errorf("No valid packet available; %v", pk.FixedHeader.Type)
+		err = fmt.Errorf("no valid packet available; %v", pk.FixedHeader.Type)
 	}
 	if err != nil {
 		return
@@ -556,9 +560,14 @@ func (i *Inflight) Len() int {
 
 // GetAll returns all the in-flight messages.
 func (i *Inflight) GetAll() map[uint16]InflightMessage {
+	m := map[uint16]InflightMessage{}
 	i.RLock()
 	defer i.RUnlock()
-	return i.internal
+	for k, v := range i.internal {
+		m[k] = v
+	}
+
+	return m
 }
 
 // Delete removes an in-flight message from the map. Returns true if the

--- a/server/internal/clients/clients_test.go
+++ b/server/internal/clients/clients_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testClientStop = errors.New("test stop")
+var errClientStop = errors.New("test stop")
 
 func genClient() *Client {
 	c, _ := net.Pipe()
@@ -375,7 +375,7 @@ func BenchmarkClientRefreshDeadline(b *testing.B) {
 func TestClientStart(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 	time.Sleep(time.Millisecond)
 	require.Equal(t, uint32(1), atomic.LoadUint32(&cl.R.State))
 	require.Equal(t, uint32(2), atomic.LoadUint32(&cl.W.State))
@@ -383,7 +383,7 @@ func TestClientStart(t *testing.T) {
 
 func BenchmarkClientStart(b *testing.B) {
 	cl := genClient()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	for n := 0; n < b.N; n++ {
 		cl.Start()
@@ -393,7 +393,7 @@ func BenchmarkClientStart(b *testing.B) {
 func TestClientReadFixedHeader(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	cl.R.Set([]byte{packets.Connect << 4, 0x00}, 0, 2)
 	cl.R.SetPos(0, 2)
@@ -412,7 +412,7 @@ func TestClientReadFixedHeader(t *testing.T) {
 func TestClientReadFixedHeaderDecodeError(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	o := make(chan error)
 	go func() {
@@ -428,7 +428,7 @@ func TestClientReadFixedHeaderDecodeError(t *testing.T) {
 func TestClientReadFixedHeaderReadEOF(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	o := make(chan error)
 	go func() {
@@ -447,7 +447,7 @@ func TestClientReadFixedHeaderReadEOF(t *testing.T) {
 func TestClientReadFixedHeaderNoLengthTerminator(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	o := make(chan error)
 	go func() {
@@ -464,7 +464,7 @@ func TestClientReadFixedHeaderNoLengthTerminator(t *testing.T) {
 func TestClientReadOK(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	// Two packets in a row...
 	b := []byte{
@@ -525,7 +525,7 @@ func TestClientReadOK(t *testing.T) {
 func TestClientClearBuffers(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	cl.Stop(testClientStop)
+	cl.Stop(errClientStop)
 	cl.ClearBuffers()
 
 	require.Nil(t, cl.W)
@@ -535,7 +535,7 @@ func TestClientClearBuffers(t *testing.T) {
 func TestClientReadDone(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 	cl.State.Done = 1
 
 	err := cl.Read(func(cl *Client, pk packets.Packet) error {
@@ -548,7 +548,7 @@ func TestClientReadDone(t *testing.T) {
 func TestClientReadPacketError(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	b := []byte{
 		0, 18,
@@ -592,15 +592,15 @@ func TestClientReadPacketEOF(t *testing.T) {
 	}()
 
 	cl.R.Stop()
-	cl.Stop(testClientStop)
+	cl.Stop(errClientStop)
 	require.Error(t, <-o)
-	require.True(t, errors.Is(cl.StopCause(), testClientStop))
+	require.True(t, errors.Is(cl.StopCause(), errClientStop))
 }
 
 func TestClientReadHandlerErr(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	b := []byte{
 		byte(packets.Publish << 4), 11, // Fixed header
@@ -623,7 +623,7 @@ func TestClientReadHandlerErr(t *testing.T) {
 func TestClientReadPacketOK(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	err := cl.R.Set([]byte{
 		byte(packets.Publish << 4), 11, // Fixed header
@@ -655,7 +655,7 @@ func TestClientReadPacketOK(t *testing.T) {
 func TestClientReadPacket(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	for i, tt := range pkTable {
 		err := cl.R.Set(tt.bytes, 0, len(tt.bytes))
@@ -680,7 +680,7 @@ func TestClientReadPacket(t *testing.T) {
 func TestClientReadPacketReadingError(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 
 	err := cl.R.Set([]byte{
 		0, 11, // Fixed header
@@ -701,7 +701,7 @@ func TestClientReadPacketReadingError(t *testing.T) {
 func TestClientReadPacketReadError(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 	cl.R.Stop()
 
 	_, err := cl.ReadPacket(&packets.FixedHeader{
@@ -714,7 +714,7 @@ func TestClientReadPacketReadError(t *testing.T) {
 func TestClientReadPacketReadUnknown(t *testing.T) {
 	cl := genClient()
 	cl.Start()
-	defer cl.Stop(testClientStop)
+	defer cl.Stop(errClientStop)
 	cl.R.Stop()
 
 	_, err := cl.ReadPacket(&packets.FixedHeader{
@@ -745,14 +745,14 @@ func TestClientWritePacket(t *testing.T) {
 
 		require.Equal(t, tt.bytes, <-o, "Mismatched packet: [i:%d] %d", i, tt.bytes[0])
 
-		cl.Stop(testClientStop)
+		cl.Stop(errClientStop)
 		time.Sleep(time.Millisecond * 1)
 
 		// The stop cause is either the test error, EOF, or a
 		// closed pipe, depending on which goroutine runs first.
 		err = cl.StopCause()
 		require.True(t,
-			errors.Is(err, testClientStop) ||
+			errors.Is(err, errClientStop) ||
 				errors.Is(err, io.EOF) ||
 				errors.Is(err, io.ErrClosedPipe))
 
@@ -768,7 +768,7 @@ func TestClientWritePacketWriteNoConn(t *testing.T) {
 	c, _ := net.Pipe()
 	cl := NewClient(c, circ.NewReader(16, 4), circ.NewWriter(16, 4), new(system.Info))
 	cl.W.SetPos(0, 16)
-	cl.Stop(testClientStop)
+	cl.Stop(errClientStop)
 
 	_, err := cl.WritePacket(pkTable[1].packet)
 	require.Error(t, err)

--- a/server/server.go
+++ b/server/server.go
@@ -140,7 +140,7 @@ func NewServer(opts *Options) *Server {
 		inflightResendTicker: time.NewTicker(time.Duration(10) * time.Second),
 		inline: inlineMessages{
 			done: make(chan bool),
-			pub:  make(chan packets.Packet, 1024),
+			pub:  make(chan packets.Packet, 4096),
 		},
 		Events:  events.Events{},
 		Options: opts,


### PR DESCRIPTION
As per #98 and #96 - a data race was occurring when the primary server routine and client routines attempted to access the client inflight messages map at the same time, causing fatal errors.

The issue was reproduced placing the server under heavy load with inovex/mqtt-stresser, using qos=2 for both the publisher and subscriber (see #98). 

This PR fixes the issue by returning reference maps of the original values, values in the case of inflight messages, pointers to clients in the case of the client map.

* The inflight messages are never modified by reference once set, so it is reasonable and more cost effective to copy the whole value.
* The clients are passed by reference, and have more sophisticated locking mechanisms and isolation.

Profiling the solution before and after show a small but negligible reduction in mallocs. When running the above mentioned stress tests, data races or crashes are detected are no longer detected.

With many thanks to @muXxer for identifying the issue and providing a potential solution in #96 :)

Additionally, this PR increases the size of the inline publishing buffer in light of #95.
Finally, error message var naming in clients_test has been updated to better meet code standards.