### PR TITLE
Variable existed in the method processSubscribe is unstable

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -844,7 +844,7 @@ func TestServerUnsubscribeClient(t *testing.T) {
 	s.Topics.Subscribe(cl.ID, pk)
 	subs := s.Topics.Subscribers("a/b/c")
 	require.Equal(t, 1, len(subs.Subscriptions))
-	s.unsubscribeClient(cl)
+	s.UnsubscribeClient(cl)
 	subs = s.Topics.Subscribers("a/b/c")
 	require.Equal(t, 0, len(subs.Subscriptions))
 }


### PR DESCRIPTION
The variable existed can be changed repeatedly within a for loop. An array variable must be used to record the subscription of each filter.