### PR TITLE
Connect ReturnResponseInfo only applies to Connack values

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -477,8 +477,8 @@ func (cl *Client) WritePacket(pk packets.Packet) error {
 		pk.Mods.DisallowProblemInfo = true // [MQTT-3.1.2-29] strict, no problem info on any packet if set
 	}
 
-	if cl.Properties.Props.RequestResponseInfo == 0x1 || cl.ops.capabilities.Compatibilities.AlwaysReturnResponseInfo {
-		pk.Mods.AllowResponseInfo = true // NB we need to know which properties we can encode
+	if pk.FixedHeader.Type != packets.Connack || cl.Properties.Props.RequestResponseInfo == 0x1 || cl.ops.capabilities.Compatibilities.AlwaysReturnResponseInfo {
+		pk.Mods.AllowResponseInfo = true // [MQTT-3.1.2-28] we need to know which properties we can encode
 	}
 
 	pk = cl.ops.hooks.OnPacketEncode(cl, pk)

--- a/examples/paho.testing/main.go
+++ b/examples/paho.testing/main.go
@@ -29,7 +29,6 @@ func main() {
 	server.Options.Capabilities.ServerKeepAlive = 60
 	server.Options.Capabilities.Compatibilities.ObscureNotAuthorized = true
 	server.Options.Capabilities.Compatibilities.PassiveClientDisconnect = true
-	server.Options.Capabilities.Compatibilities.AlwaysReturnResponseInfo = true
 
 	_ = server.AddHook(new(pahoAuthHook), nil)
 	tcp := listeners.NewTCP("t1", ":1883", nil)


### PR DESCRIPTION
As per #126, the current implementation of RequestResponseInfo applies to all packets following a connect. This is due to a misinterpretation of the specification. The MQTT v5 specification indicates that the Connect property RequestResponseInfo should only refer to the Connack response properties. This PR adjusted the logic for AllowResponseInfo to ensure it only applies to Connack packets if byte is 0x1, if Compatibilities.AlwaysReturnResponseInfo is set, or the packet is any other type.

Additionally, it removes the usage of Compatibilities.AlwaysReturnResponseInfo in examples/paho/main.go. 