### PR TITLE
Use Atomic instead of RWMutex for Hooks concurrency

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -110,7 +110,7 @@ type HookOptions struct {
 // Hooks is a slice of Hook interfaces to be called in sequence.
 type Hooks struct {
 	Log          *zerolog.Logger // a logger for the hook (from the server)
-	internal     []Hook          // a slice of hooks
+	internal     atomic.Value    // a slice of hooks
 	wg           sync.WaitGroup  // a waitgroup for syncing hook shutdown
 	qty          int64           // the number of hooks in use
 	sync.RWMutex                 // a mutex
@@ -136,18 +136,18 @@ func (h *Hooks) Provides(b ...byte) bool {
 
 // Add adds and initializes a new hook.
 func (h *Hooks) Add(hook Hook, config any) error {
-	h.Lock()
-	defer h.Unlock()
-	if h.internal == nil {
-		h.internal = []Hook{}
-	}
-
 	err := hook.Init(config)
 	if err != nil {
 		return fmt.Errorf("failed initialising %s hook: %w", hook.ID(), err)
 	}
 
-	h.internal = append(h.internal, hook)
+	i, ok := h.internal.Load().([]Hook)
+	if !ok {
+		i = []Hook{}
+	}
+
+	i = append(i, hook)
+	h.internal.Store(i)
 	atomic.AddInt64(&h.qty, 1)
 	h.wg.Add(1)
 
@@ -156,9 +156,12 @@ func (h *Hooks) Add(hook Hook, config any) error {
 
 // GetAll returns a slice of all the hooks.
 func (h *Hooks) GetAll() []Hook {
-	h.RLock()
-	defer h.RUnlock()
-	return append([]Hook{}, h.internal...)
+	i, ok := h.internal.Load().([]Hook)
+	if !ok {
+		return []Hook{}
+	}
+
+	return i
 }
 
 // Stop indicates all attached hooks to gracefully end.

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -27,6 +27,10 @@ type modifiedHookBase struct {
 
 var errTestHook = errors.New("error")
 
+func (h *modifiedHookBase) ID() string {
+	return "modified"
+}
+
 func (h *modifiedHookBase) Init(config any) error {
 	if config != nil {
 		return errTestHook
@@ -178,12 +182,20 @@ func TestHooksProvides(t *testing.T) {
 	require.False(t, h.Provides(OnDisconnect))
 }
 
-func TestHooksAddAndLen(t *testing.T) {
+func TestHooksAddLenGetAll(t *testing.T) {
 	h := new(Hooks)
 	err := h.Add(new(HookBase), nil)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), atomic.LoadInt64(&h.qty))
-	require.Equal(t, int64(1), h.Len())
+
+	err = h.Add(new(modifiedHookBase), nil)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(2), atomic.LoadInt64(&h.qty))
+	require.Equal(t, int64(2), h.Len())
+
+	all := h.GetAll()
+	require.Equal(t, "base", all[0].ID())
+	require.Equal(t, "modified", all[1].ID())
 }
 
 func TestHooksAddInitFailure(t *testing.T) {


### PR DESCRIPTION
As per discussion in #145, converts RWMutex protection of Hooks slice to use atomic.Value instead.

cc @thedevop - please check and review 🙇🏻 