### PR TITLE
invalid config type provided

### DIFF
--- a/examples/persistence/bolt/main.go
+++ b/examples/persistence/bolt/main.go
@@ -30,12 +30,15 @@ func main() {
 	server := mqtt.New(nil)
 	_ = server.AddHook(new(auth.AllowHook), nil)
 
-	err := server.AddHook(new(bolt.Hook), bolt.Options{
+	err := server.AddHook(new(bolt.Hook), &bolt.Options{
 		Path: "bolt.db",
 		Options: &bbolt.Options{
 			Timeout: 500 * time.Millisecond,
 		},
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	tcp := listeners.NewTCP("t1", ":1883", nil)
 	err = server.AddListener(tcp)

--- a/server.go
+++ b/server.go
@@ -467,13 +467,11 @@ func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
 			return false // [MQTT-3.2.2-3]
 		}
 
-		infLen := existing.State.Inflight.Len()
-		if infLen > 0 {
+		if existing.State.Inflight.Len() > 0 {
 			cl.State.Inflight = existing.State.Inflight // [MQTT-3.1.2-5]
 			if cl.State.Inflight.maximumReceiveQuota == 0 && cl.ops.capabilities.ReceiveMaximum != 0 {
 				cl.State.Inflight.ResetReceiveQuota(int32(cl.ops.capabilities.ReceiveMaximum)) // server receive max per client
 				cl.State.Inflight.ResetSendQuota(int32(cl.Properties.Props.ReceiveMaximum))    // client receive max
-				cl.State.Inflight.receiveQuota -= int32(infLen)                                // available receive quota is equal to the maximum quota minus the number of inflight messages
 			}
 		}
 		

--- a/server.go
+++ b/server.go
@@ -467,7 +467,16 @@ func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
 			return false // [MQTT-3.2.2-3]
 		}
 
-		cl.State.Inflight = existing.State.Inflight // [MQTT-3.1.2-5]
+		infLen := existing.State.Inflight.Len()
+		if infLen > 0 {
+			cl.State.Inflight = existing.State.Inflight // [MQTT-3.1.2-5]
+			if cl.State.Inflight.maximumReceiveQuota == 0 && cl.ops.capabilities.ReceiveMaximum != 0 {
+				cl.State.Inflight.ResetReceiveQuota(int32(cl.ops.capabilities.ReceiveMaximum)) // server receive max per client
+				cl.State.Inflight.ResetSendQuota(int32(cl.Properties.Props.ReceiveMaximum))    // client receive max
+				cl.State.Inflight.receiveQuota -= int32(infLen)                                // available receive quota is equal to the maximum quota minus the number of inflight messages
+			}
+		}
+		
 		for _, sub := range existing.State.Subscriptions.GetAll() {
 			existed := !s.Topics.Subscribe(cl.ID, sub) // [MQTT-3.8.4-3]
 			if !existed {


### PR DESCRIPTION
examples/persistence/bolt/main.go: invalid config type provided