### PR TITLE
No longer issue retained messages on session takeover

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -208,7 +208,10 @@ func (pk *Packet) Copy(allowTransfer bool) Packet {
 		Created:        pk.Created,
 		Expiry:         pk.Expiry,
 		Origin:         pk.Origin,
-		PacketID:       pk.PacketID, // ... ? Packet ID must not be transferred (in this manner)
+	}
+
+	if allowTransfer {
+		p.PacketID = pk.PacketID
 	}
 
 	if len(pk.Connect.ProtocolName) > 0 {

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -464,6 +464,9 @@ func TestCopy(t *testing.T) {
 		require.Equal(t, tt.Packet.Created, pkc.Created, pkInfo, tt.Case, tt.Desc)
 		require.Equal(t, tt.Packet.Origin, pkc.Origin, pkInfo, tt.Case, tt.Desc)
 		require.EqualValues(t, pkc.Properties, tt.Packet.Properties)
+
+		pkcc := tt.Packet.Copy(false)
+		require.Equal(t, uint16(0), pkcc.PacketID, pkInfo, tt.Case, tt.Desc)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -335,13 +335,6 @@ func (s *Server) attachClient(cl *Client, listener string) error {
 		return fmt.Errorf("ack connection packet: %w", err)
 	}
 
-	// Publish any retained messages for subscriptions which already existed on client takeover.
-	if sessionPresent {
-		for _, sub := range cl.State.Subscriptions.GetAll() {
-			s.publishRetainedToClient(cl, sub, true)
-		}
-	}
-
 	s.loop.willDelayed.Delete(cl.ID) // [MQTT-3.1.3-9]
 
 	if sessionPresent {


### PR DESCRIPTION
After an investigation into the issues seen in #153, the cause is determined to be a misreading of the specification regarding the issuance of retained messages on session takeover, confirmed in this comment by Andy Stanford-Clark https://groups.google.com/g/mqtt/c/ZUpadJna_tA

As such, we will no longer issue retained messages when a session takeover occurs. QoS Inflight queueing continues to behave as expected.