### PR TITLE
Fix potential NextPacketID endless loop, expand tests

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -252,7 +252,12 @@ func (cl *Client) refreshDeadline(keepalive uint16) {
 func (cl *Client) NextPacketID() (i uint32, err error) {
 	cl.Lock()
 	defer cl.Unlock()
+
 	i = atomic.LoadUint32(&cl.State.packetID)
+	if i >= 65535 {
+		i = 0
+	}
+
 	started := i + 1
 	overflowed := false
 	for {

--- a/clients.go
+++ b/clients.go
@@ -254,31 +254,26 @@ func (cl *Client) NextPacketID() (i uint32, err error) {
 	defer cl.Unlock()
 
 	i = atomic.LoadUint32(&cl.State.packetID)
-	if i >= 65535 {
-		i = 0
-	}
-
-	started := i + 1
+	started := i
 	overflowed := false
 	for {
-		if i >= 65535 {
-			overflowed = true
-			i = 1
-		} else {
-			i++
-		}
-
 		if overflowed && i == started {
 			return 0, packets.ErrQuotaExceeded
 		}
 
+		if i >= cl.ops.capabilities.maximumPacketID {
+			overflowed = true
+			i = 0
+			continue
+		}
+
+		i++
+
 		if _, ok := cl.State.Inflight.Get(uint16(i)); !ok {
-			break
+			atomic.StoreUint32(&cl.State.packetID, i)
+			return i, nil
 		}
 	}
-
-	atomic.StoreUint32(&cl.State.packetID, i)
-	return i, nil
 }
 
 // ResendInflightMessages attempts to resend any pending inflight messages to connected clients.

--- a/clients_test.go
+++ b/clients_test.go
@@ -33,6 +33,7 @@ func newTestClient() (cl *Client, r net.Conn, w net.Conn) {
 			ReceiveMaximum:             10,
 			TopicAliasMaximum:          10000,
 			MaximumClientWritesPending: 3,
+			maximumPacketID:            10,
 		},
 	})
 
@@ -241,29 +242,29 @@ func TestClientNextPacketIDInUse(t *testing.T) {
 
 func TestClientNextPacketIDExhausted(t *testing.T) {
 	cl, _, _ := newTestClient()
-	for i := 0; i <= 65535; i++ {
-		cl.State.Inflight.Set(packets.Packet{PacketID: uint16(i)})
+	for i := uint32(1); i <= cl.ops.capabilities.maximumPacketID; i++ {
+		cl.State.Inflight.internal[uint16(i)] = packets.Packet{PacketID: uint16(i)}
 	}
 
 	i, err := cl.NextPacketID()
-	require.Equal(t, uint32(0), i)
 	require.Error(t, err)
 	require.ErrorIs(t, err, packets.ErrQuotaExceeded)
+	require.Equal(t, uint32(0), i)
 }
 
 func TestClientNextPacketIDOverflow(t *testing.T) {
 	cl, _, _ := newTestClient()
-	for i := uint16(0); i < 65535; i++ {
-		cl.State.Inflight.internal[i] = packets.Packet{}
+	for i := uint32(0); i < cl.ops.capabilities.maximumPacketID; i++ {
+		cl.State.Inflight.internal[uint16(i)] = packets.Packet{}
 	}
 
-	cl.State.packetID = uint32(65534)
+	cl.State.packetID = uint32(cl.ops.capabilities.maximumPacketID - 1)
 	i, err := cl.NextPacketID()
 	require.NoError(t, err)
-	require.Equal(t, uint32(65535), i)
-	cl.State.Inflight.internal[65535] = packets.Packet{}
+	require.Equal(t, cl.ops.capabilities.maximumPacketID, i)
+	cl.State.Inflight.internal[uint16(cl.ops.capabilities.maximumPacketID)] = packets.Packet{}
 
-	cl.State.packetID = uint32(65535)
+	cl.State.packetID = cl.ops.capabilities.maximumPacketID
 	_, err = cl.NextPacketID()
 	require.Error(t, err)
 	require.ErrorIs(t, err, packets.ErrQuotaExceeded)

--- a/packets/codec_test.go
+++ b/packets/codec_test.go
@@ -376,7 +376,7 @@ func TestEncodeUint16(t *testing.T) {
 	result = encodeUint16(32767)
 	require.Equal(t, []byte{0x7f, 0xff}, result)
 
-	result = encodeUint16(65535)
+	result = encodeUint16(math.MaxUint16)
 	require.Equal(t, []byte{0xff, 0xff}, result)
 }
 

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -442,11 +443,11 @@ func (pk *Packet) ConnectValidate() Code {
 		return ErrProtocolViolationReservedBit // [MQTT-3.1.2-3]
 	}
 
-	if len(pk.Connect.Password) > 65535 {
+	if len(pk.Connect.Password) > math.MaxUint16 {
 		return ErrProtocolViolationPasswordTooLong
 	}
 
-	if len(pk.Connect.Username) > 65535 {
+	if len(pk.Connect.Username) > math.MaxUint16 {
 		return ErrProtocolViolationUsernameTooLong
 	}
 
@@ -466,7 +467,7 @@ func (pk *Packet) ConnectValidate() Code {
 		return ErrProtocolViolationPasswordNoFlag // [MQTT-3.1.2-18]
 	}
 
-	if len(pk.Connect.ClientIdentifier) > 65535 {
+	if len(pk.Connect.ClientIdentifier) > math.MaxUint16 {
 		return ErrClientIdentifierNotValid
 	}
 

--- a/server.go
+++ b/server.go
@@ -58,6 +58,7 @@ type Capabilities struct {
 	MaximumClientWritesPending   int32
 	MaximumSessionExpiryInterval uint32
 	MaximumPacketSize            uint32
+	maximumPacketID              uint32 // unexported, used for testing only
 	ReceiveMaximum               uint16
 	TopicAliasMaximum            uint16
 	ServerKeepAlive              uint16
@@ -170,6 +171,8 @@ func (o *Options) ensureDefaults() {
 	if o.Capabilities == nil {
 		o.Capabilities = DefaultServerCapabilities
 	}
+
+	o.Capabilities.maximumPacketID = math.MaxUint16 // spec maximum is 65535
 
 	if o.SysTopicResendInterval == 0 {
 		o.SysTopicResendInterval = defaultSysTopicInterval

--- a/server_test.go
+++ b/server_test.go
@@ -1450,7 +1450,7 @@ func TestPublishToClientServerTopicAlias(t *testing.T) {
 func TestPublishToClientExhaustedPacketID(t *testing.T) {
 	s := newServer()
 	cl, _, _ := newTestClient()
-	for i := 0; i <= 65535; i++ {
+	for i := uint32(0); i <= cl.ops.capabilities.maximumPacketID; i++ {
 		cl.State.Inflight.Set(packets.Packet{PacketID: uint16(i)})
 	}
 
@@ -1519,7 +1519,7 @@ func TestPublishToSubscribersExhaustedPacketIDs(t *testing.T) {
 	s := newServer()
 	cl, r, w := newTestClient()
 	s.Clients.Add(cl)
-	for i := 0; i <= 65535; i++ {
+	for i := uint32(0); i <= cl.ops.capabilities.maximumPacketID; i++ {
 		cl.State.Inflight.Set(packets.Packet{PacketID: 1})
 	}
 


### PR DESCRIPTION
Fixes potential endless loop scenario with clients.NextPacketID and updates related tests to cover this scenario.
cc @thedevop Thank you for your code sample - it really helped illustrate the issue!