### PR TITLE
Use *packets.Packet for outbound chan

### DIFF
--- a/server.go
+++ b/server.go
@@ -831,7 +831,7 @@ func (s *Server) publishToClient(cl *Client, sub packets.Subscription, pk packet
 	}
 
 	select {
-	case cl.State.outbound <- out:
+	case cl.State.outbound <- &out:
 		atomic.AddInt32(&cl.State.outboundQty, 1)
 	default:
 		atomic.AddInt64(&s.Info.MessagesDropped, 1)

--- a/server_test.go
+++ b/server_test.go
@@ -1408,7 +1408,7 @@ func TestPublishToClientExceedClientWritesPending(t *testing.T) {
 	s.Clients.Add(cl)
 
 	for i := int32(0); i < cl.ops.capabilities.MaximumClientWritesPending; i++ {
-		cl.State.outbound <- packets.Packet{}
+		cl.State.outbound <- &packets.Packet{}
 		atomic.AddInt32(&cl.State.outboundQty, 1)
 	}
 


### PR DESCRIPTION
This is the minimum change needed to use *packets.Packet for outbound chan. I do suggest more use of point to packets.Packet for internal calls, as it will result in less copy/memory allocation, for example cl.WritePacket. Fix #175. 