### PR TITLE
Correctly identify and clean taken-over sessions

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -142,6 +142,7 @@ type ClientState struct {
 	disconnected  int64                // the time the client disconnected in unix time, for calculating expiry
 	outbound      chan *packets.Packet // queue for pending outbound packets
 	endOnce       sync.Once            // only end once
+	isTakenOver   uint32               // used to identify orphaned clients
 	packetID      uint32               // the current highest packetID
 	done          uint32               // atomic counter which indicates that the client has closed
 	outboundQty   int32                // number of messages currently in the outbound queue

--- a/inflight.go
+++ b/inflight.go
@@ -58,6 +58,18 @@ func (i *Inflight) Len() int {
 	return len(i.internal)
 }
 
+// Clone returns a new instance of Inflight with the same message data.
+// This is used when transferring inflights from a taken-over session.
+func (i *Inflight) Clone() *Inflight {
+	c := NewInflights()
+	i.RLock()
+	defer i.RUnlock()
+	for k, v := range i.internal {
+		c.internal[k] = v
+	}
+	return c
+}
+
 // GetAll returns all the inflight messages.
 func (i *Inflight) GetAll(immediate bool) []packets.Packet {
 	i.RLock()

--- a/inflight_test.go
+++ b/inflight_test.go
@@ -61,6 +61,16 @@ func TestInflightLen(t *testing.T) {
 	require.Equal(t, 1, cl.State.Inflight.Len())
 }
 
+func TestInflightClone(t *testing.T) {
+	cl, _, _ := newTestClient()
+	cl.State.Inflight.Set(packets.Packet{PacketID: 2})
+	require.Equal(t, 1, cl.State.Inflight.Len())
+
+	cloned := cl.State.Inflight.Clone()
+	require.NotNil(t, cloned)
+	require.NotSame(t, cloned, cl.State.Inflight)
+}
+
 func TestInflightDelete(t *testing.T) {
 	cl, _, _ := newTestClient()
 

--- a/packets/tpackets.go
+++ b/packets/tpackets.go
@@ -250,26 +250,26 @@ var TPacketData = map[byte]TPacketCases{
 			Desc:    "mqtt v3.1.1",
 			Primary: true,
 			RawBytes: []byte{
-				Connect << 4, 16, // Fixed header
+				Connect << 4, 15, // Fixed header
 				0, 4, // Protocol Name - MSB+LSB
 				'M', 'Q', 'T', 'T', // Protocol Name
 				4,     // Protocol Version
 				0,     // Packet Flags
 				0, 60, // Keepalive
-				0, 4, // Client ID - MSB+LSB
-				'z', 'e', 'n', '3', // Client ID "zen"
+				0, 3, // Client ID - MSB+LSB
+				'z', 'e', 'n', // Client ID "zen"
 			},
 			Packet: &Packet{
 				FixedHeader: FixedHeader{
 					Type:      Connect,
-					Remaining: 16,
+					Remaining: 15,
 				},
 				ProtocolVersion: 4,
 				Connect: ConnectParams{
 					ProtocolName:     []byte("MQTT"),
 					Clean:            false,
 					Keepalive:        60,
-					ClientIdentifier: "zen3",
+					ClientIdentifier: "zen",
 				},
 			},
 		},
@@ -426,9 +426,9 @@ var TPacketData = map[byte]TPacketCases{
 				Connect << 4, 28, // Fixed header
 				0, 4, // Protocol Name - MSB+LSB
 				'M', 'Q', 'T', 'T', // Protocol Name
-				4,     // Protocol Version
-				194,   // Packet Flags
-				0, 20, // Keepalive
+				4,               // Protocol Version
+				0 | 1<<6 | 1<<7, // Packet Flags
+				0, 20,           // Keepalive
 				0, 3, // Client ID - MSB+LSB
 				'z', 'e', 'n', // Client ID "zen"
 				0, 5, // Username MSB+LSB
@@ -444,7 +444,7 @@ var TPacketData = map[byte]TPacketCases{
 				ProtocolVersion: 4,
 				Connect: ConnectParams{
 					ProtocolName:     []byte("MQTT"),
-					Clean:            true,
+					Clean:            false,
 					Keepalive:        20,
 					ClientIdentifier: "zen",
 					UsernameFlag:     true,

--- a/server.go
+++ b/server.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	Version                       = "2.2.3" // the current server version.
+	Version                       = "2.2.4" // the current server version.
 	defaultSysTopicInterval int64 = 1       // the interval between $SYS topic publishes
 )
 
@@ -353,9 +353,7 @@ func (s *Server) attachClient(cl *Client, listener string) error {
 	if err != nil {
 		s.sendLWT(cl)
 		cl.Stop(err)
-	}
-
-	if err == nil {
+	} else {
 		cl.Properties.Will = Will{} // [MQTT-3.14.4-3] [MQTT-3.1.2-10]
 	}
 
@@ -365,9 +363,11 @@ func (s *Server) attachClient(cl *Client, listener string) error {
 	close(cl.State.outbound)
 
 	if expire {
-		s.UnsubscribeClient(cl)
 		cl.ClearInflights(math.MaxInt64, 0)
-		s.Clients.Delete(cl.ID) // [MQTT-4.1.0-2] ![MQTT-3.1.2-23]
+		s.UnsubscribeClient(cl)
+		if atomic.LoadUint32(&cl.State.isTakenOver) == 0 {
+			s.Clients.Delete(cl.ID) // [MQTT-4.1.0-2] ![MQTT-3.1.2-23]
+		}
 	}
 
 	return err
@@ -440,17 +440,17 @@ func (s *Server) validateConnect(cl *Client, pk packets.Packet) packets.Code {
 // session is abandoned.
 func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
 	if existing, ok := s.Clients.Get(pk.Connect.ClientIdentifier); ok {
-		s.DisconnectClient(existing, packets.ErrSessionTakenOver)                                 // [MQTT-3.1.4-3]
-		if pk.Connect.Clean || (existing.Properties.Clean && cl.Properties.ProtocolVersion < 5) { // [MQTT-3.1.2-4] [MQTT-3.1.4-4]
+		s.DisconnectClient(existing, packets.ErrSessionTakenOver)                                       // [MQTT-3.1.4-3]
+		if pk.Connect.Clean || (existing.Properties.Clean && existing.Properties.ProtocolVersion < 5) { // [MQTT-3.1.2-4] [MQTT-3.1.4-4]
 			s.UnsubscribeClient(existing)
 			existing.ClearInflights(math.MaxInt64, 0)
 			return false // [MQTT-3.2.2-3]
 		}
 
+		atomic.StoreUint32(&existing.State.isTakenOver, 1)
+
 		if existing.State.Inflight.Len() > 0 {
-			existing.State.Inflight.Lock()
-			cl.State.Inflight = existing.State.Inflight // [MQTT-3.1.2-5]
-			existing.State.Inflight.Unlock()
+			cl.State.Inflight = existing.State.Inflight.Clone() // [MQTT-3.1.2-5]
 			if cl.State.Inflight.maximumReceiveQuota == 0 && cl.ops.capabilities.ReceiveMaximum != 0 {
 				cl.State.Inflight.ResetReceiveQuota(int32(cl.ops.capabilities.ReceiveMaximum)) // server receive max per client
 				cl.State.Inflight.ResetSendQuota(int32(cl.Properties.Props.ReceiveMaximum))    // client receive max
@@ -464,6 +464,15 @@ func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
 			}
 			cl.State.Subscriptions.Add(sub.Filter, sub)
 		}
+
+		// Clean the state of the existing client to prevent sequential take-overs
+		// from increasing memory usage by inflights + subs * client-id.
+		s.UnsubscribeClient(existing)
+		existing.ClearInflights(math.MaxInt64, 0)
+		s.Log.Debug().Str("client", cl.ID).
+			Str("old_remote", existing.Net.Remote).
+			Str("new_remote", cl.Net.Remote).
+			Msg("session taken over")
 
 		return true // [MQTT-3.2.2-3]
 	}
@@ -1087,8 +1096,15 @@ func (s *Server) UnsubscribeClient(cl *Client) {
 	i := 0
 	filterMap := cl.State.Subscriptions.GetAll()
 	filters := make([]packets.Subscription, len(filterMap))
-	for k, v := range filterMap {
+	for k := range filterMap {
 		cl.State.Subscriptions.Delete(k)
+	}
+
+	if atomic.LoadUint32(&cl.State.isTakenOver) == 1 {
+		return
+	}
+
+	for k, v := range filterMap {
 		if s.Topics.Unsubscribe(k, cl.ID) {
 			atomic.AddInt64(&s.Info.Subscriptions, -1)
 		}


### PR DESCRIPTION
An issue was highlighted in which the subscriptions for a client which has undertaken a session takeover could be cleared erroneously in #173.

This behaviour was caused by the orphaned client unsubscribing from the client's topics after the new client had already inherited the subscriptions and begun reading.

Additionally, I identified a secondary, more significant issue in which an expiring orphaned client would delete the existing client from the server client map.

This PR attempts to resolve this issue through three mechanisms:
1. By adding a new `isTakenOver` atomic bit switch to the client which is set to 1 when the client session is inherited by a new client and the client is orphaned (the pointer to the client has been, or shortly will be overwritten in the server client map).
2. The s.unsubscribeClient logic has been adjusted to operate in two steps: first, the client subscriptions are moved from the client itself. Then, unsubscribe from the server topics index is only performed if the client has _not_ been taken over. 
3. When an actively connected client connection expires, it may only be deleted from the server clients map if the client has _not_ been taken over (i.e. it is the active, operating client).

Finally, the state of existing sessions is cleaned up on all inheritance to prevent sequential take-overs from increasing memory usage by inflights + subs * client-id.

This PR adds a new test case specifically to ensure client inheritance and state cleaning is performed as expected.