### PR TITLE
Allow 0 byte usernames if correctly formed

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -412,6 +412,10 @@ func (pk *Packet) ConnectDecode(buf []byte) error {
 	}
 
 	if pk.Connect.UsernameFlag { // [MQTT-3.1.3-12]
+		if offset >= len(buf) {
+			return ErrProtocolViolationFlagNoUsername // [MQTT-3.1.2-17]
+		}
+
 		pk.Connect.Username, offset, err = decodeBytes(buf, offset)
 		if err != nil {
 			return ErrMalformedUsername
@@ -449,10 +453,6 @@ func (pk *Packet) ConnectValidate() Code {
 
 	if len(pk.Connect.Username) > math.MaxUint16 {
 		return ErrProtocolViolationUsernameTooLong
-	}
-
-	if pk.Connect.UsernameFlag && len(pk.Connect.Username) == 0 {
-		return ErrProtocolViolationFlagNoUsername // [MQTT-3.1.2-17]
 	}
 
 	if !pk.Connect.UsernameFlag && len(pk.Connect.Username) > 0 {

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -412,7 +412,7 @@ func (pk *Packet) ConnectDecode(buf []byte) error {
 	}
 
 	if pk.Connect.UsernameFlag { // [MQTT-3.1.3-12]
-		if offset >= len(buf) {
+		if offset >= len(buf) { // we are at the end of the packet
 			return ErrProtocolViolationFlagNoUsername // [MQTT-3.1.2-17]
 		}
 

--- a/packets/tpackets.go
+++ b/packets/tpackets.go
@@ -664,10 +664,9 @@ var TPacketData = map[byte]TPacketCases{
 
 		{
 			Case:      TConnectInvalidFlagNoUsername,
-			Desc:      "username flag no username bytes",
+			Desc:      "username flag with no username bytes",
 			Group:     "decode",
 			FailFirst: ErrProtocolViolationFlagNoUsername,
-			Expect:    ErrProtocolViolationFlagNoUsername,
 			RawBytes: []byte{
 				Connect << 4, 17, // Fixed header
 				0, 4, // Protocol Name - MSB+LSB


### PR DESCRIPTION
As indicated in #178, Connect packets containing a username flag and a correctly formed LSB+MSB of [0, 0], but no username bytes were returning an invalid client identifier error. 

The logic for triggering ErrProtocolViolationFlagNoUsername has been moved out of ConnectValidate where it was being called incorrectly, and instead is triggered in ConnectDecode if a username is expected but the buffer has been exhausted.