### PR TITLE
Configurable client bufio reader/writer sizes

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -156,9 +156,9 @@ func newClient(c net.Conn, o *ops) *Client {
 		State: ClientState{
 			Inflight:      NewInflights(),
 			Subscriptions: NewSubscriptions(),
-			TopicAliases:  NewTopicAliases(o.capabilities.TopicAliasMaximum),
+			TopicAliases:  NewTopicAliases(o.options.Capabilities.TopicAliasMaximum),
 			keepalive:     defaultKeepalive,
-			outbound:      make(chan *packets.Packet, o.capabilities.MaximumClientWritesPending),
+			outbound:      make(chan *packets.Packet, o.options.Capabilities.MaximumClientWritesPending),
 		},
 		Properties: ClientProperties{
 			ProtocolVersion: defaultClientProtocolVersion, // default protocol version
@@ -168,8 +168,11 @@ func newClient(c net.Conn, o *ops) *Client {
 
 	if c != nil {
 		cl.Net = ClientConnection{
-			Conn:   c,
-			bconn:  bufio.NewReadWriter(bufio.NewReader(c), bufio.NewWriter(c)),
+			Conn: c,
+			bconn: bufio.NewReadWriter(
+				bufio.NewReaderSize(c, o.options.ClientNetReadBufferSize),
+				bufio.NewWriterSize(c, o.options.ClientNetReadBufferSize),
+			),
 			Remote: c.RemoteAddr().String(),
 		}
 	}
@@ -198,8 +201,8 @@ func (cl *Client) ParseConnect(lid string, pk packets.Packet) {
 	cl.Properties.Clean = pk.Connect.Clean
 	cl.Properties.Props = pk.Properties.Copy(false)
 
-	cl.State.Inflight.ResetReceiveQuota(int32(cl.ops.capabilities.ReceiveMaximum)) // server receive max per client
-	cl.State.Inflight.ResetSendQuota(int32(cl.Properties.Props.ReceiveMaximum))    // client receive max
+	cl.State.Inflight.ResetReceiveQuota(int32(cl.ops.options.Capabilities.ReceiveMaximum)) // server receive max per client
+	cl.State.Inflight.ResetSendQuota(int32(cl.Properties.Props.ReceiveMaximum))            // client receive max
 
 	cl.State.TopicAliases.Outbound = NewOutboundTopicAliases(cl.Properties.Props.TopicAliasMaximum)
 
@@ -209,7 +212,7 @@ func (cl *Client) ParseConnect(lid string, pk packets.Packet) {
 		cl.Properties.Props.AssignedClientID = cl.ID
 	}
 
-	cl.State.keepalive = cl.ops.capabilities.ServerKeepAlive
+	cl.State.keepalive = cl.ops.options.Capabilities.ServerKeepAlive
 	if pk.Connect.Keepalive > 0 {
 		cl.State.keepalive = pk.Connect.Keepalive // [MQTT-3.2.2-22]
 	}
@@ -262,7 +265,7 @@ func (cl *Client) NextPacketID() (i uint32, err error) {
 			return 0, packets.ErrQuotaExceeded
 		}
 
-		if i >= cl.ops.capabilities.maximumPacketID {
+		if i >= cl.ops.options.Capabilities.maximumPacketID {
 			overflowed = true
 			i = 0
 			continue
@@ -405,7 +408,7 @@ func (cl *Client) ReadFixedHeader(fh *packets.FixedHeader) error {
 		return err
 	}
 
-	if cl.ops.capabilities.MaximumPacketSize > 0 && uint32(fh.Remaining+1) > cl.ops.capabilities.MaximumPacketSize {
+	if cl.ops.options.Capabilities.MaximumPacketSize > 0 && uint32(fh.Remaining+1) > cl.ops.options.Capabilities.MaximumPacketSize {
 		return packets.ErrPacketTooLarge // [MQTT-3.2.2-15]
 	}
 
@@ -497,7 +500,7 @@ func (cl *Client) WritePacket(pk packets.Packet) error {
 		pk.Mods.DisallowProblemInfo = true // [MQTT-3.1.2-29] strict, no problem info on any packet if set
 	}
 
-	if pk.FixedHeader.Type != packets.Connack || cl.Properties.Props.RequestResponseInfo == 0x1 || cl.ops.capabilities.Compatibilities.AlwaysReturnResponseInfo {
+	if pk.FixedHeader.Type != packets.Connack || cl.Properties.Props.RequestResponseInfo == 0x1 || cl.ops.options.Capabilities.Compatibilities.AlwaysReturnResponseInfo {
 		pk.Mods.AllowResponseInfo = true // [MQTT-3.1.2-28] we need to know which properties we can encode
 	}
 

--- a/server.go
+++ b/server.go
@@ -86,6 +86,12 @@ type Options struct {
 	// 	server.Options.Capabilities.MaximumClientWritesPending = 16 * 1024
 	Capabilities *Capabilities
 
+	// ClientNetWriteBufferSize specifies the size of the client *bufio.Writer write buffer.
+	ClientNetWriteBufferSize int
+
+	// ClientNetReadBufferSize specifies the size of the client *bufio.Reader read buffer.
+	ClientNetReadBufferSize int
+
 	// Logger specifies a custom configured implementation of zerolog to override
 	// the servers default logger configuration. If you wish to change the log level,
 	// of the default logger, you can do so by setting
@@ -124,10 +130,10 @@ type loop struct {
 
 // ops contains server values which can be propagated to other structs.
 type ops struct {
-	capabilities *Capabilities   // a pointer to the server capabilities, for referencing in clients
-	info         *system.Info    // pointers to server system info
-	hooks        *Hooks          // pointer to the server hooks
-	log          *zerolog.Logger // a structured logger for the client
+	options *Options        // a pointer to the server options and capabilities, for referencing in clients
+	info    *system.Info    // pointers to server system info
+	hooks   *Hooks          // pointer to the server hooks
+	log     *zerolog.Logger // a structured logger for the client
 }
 
 // New returns a new instance of mochi mqtt broker. Optional parameters
@@ -178,6 +184,14 @@ func (o *Options) ensureDefaults() {
 		o.SysTopicResendInterval = defaultSysTopicInterval
 	}
 
+	if o.ClientNetWriteBufferSize == 0 {
+		o.ClientNetWriteBufferSize = 1024 * 2
+	}
+
+	if o.ClientNetReadBufferSize == 0 {
+		o.ClientNetReadBufferSize = 1024 * 2
+	}
+
 	if o.Logger == nil {
 		log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.InfoLevel).Output(zerolog.ConsoleWriter{Out: os.Stderr})
 		o.Logger = &log
@@ -190,10 +204,10 @@ func (o *Options) ensureDefaults() {
 // topic validation checks.
 func (s *Server) NewClient(c net.Conn, listener string, id string, inline bool) *Client {
 	cl := newClient(c, &ops{ // [MQTT-3.1.2-6] implicit
-		capabilities: s.Options.Capabilities,
-		info:         s.Info,
-		hooks:        s.hooks,
-		log:          s.Log,
+		options: s.Options,
+		info:    s.Info,
+		hooks:   s.hooks,
+		log:     s.Log,
 	})
 
 	cl.ID = id
@@ -449,9 +463,9 @@ func (s *Server) inheritClientSession(pk packets.Packet, cl *Client) bool {
 		atomic.StoreUint32(&existing.State.isTakenOver, 1)
 		if existing.State.Inflight.Len() > 0 {
 			cl.State.Inflight = existing.State.Inflight.Clone() // [MQTT-3.1.2-5]
-			if cl.State.Inflight.maximumReceiveQuota == 0 && cl.ops.capabilities.ReceiveMaximum != 0 {
-				cl.State.Inflight.ResetReceiveQuota(int32(cl.ops.capabilities.ReceiveMaximum)) // server receive max per client
-				cl.State.Inflight.ResetSendQuota(int32(cl.Properties.Props.ReceiveMaximum))    // client receive max
+			if cl.State.Inflight.maximumReceiveQuota == 0 && cl.ops.options.Capabilities.ReceiveMaximum != 0 {
+				cl.State.Inflight.ResetReceiveQuota(int32(cl.ops.options.Capabilities.ReceiveMaximum)) // server receive max per client
+				cl.State.Inflight.ResetSendQuota(int32(cl.Properties.Props.ReceiveMaximum))            // client receive max
 			}
 		}
 

--- a/server_test.go
+++ b/server_test.go
@@ -1535,14 +1535,16 @@ func TestPublishToClientExceedClientWritesPending(t *testing.T) {
 		info:  new(system.Info),
 		hooks: new(Hooks),
 		log:   &logger,
-		capabilities: &Capabilities{
-			MaximumClientWritesPending: 3,
+		options: &Options{
+			Capabilities: &Capabilities{
+				MaximumClientWritesPending: 3,
+			},
 		},
 	})
 
 	s.Clients.Add(cl)
 
-	for i := int32(0); i < cl.ops.capabilities.MaximumClientWritesPending; i++ {
+	for i := int32(0); i < cl.ops.options.Capabilities.MaximumClientWritesPending; i++ {
 		cl.State.outbound <- new(packets.Packet)
 		atomic.AddInt32(&cl.State.outboundQty, 1)
 	}
@@ -1585,7 +1587,7 @@ func TestPublishToClientServerTopicAlias(t *testing.T) {
 func TestPublishToClientExhaustedPacketID(t *testing.T) {
 	s := newServer()
 	cl, _, _ := newTestClient()
-	for i := uint32(0); i <= cl.ops.capabilities.maximumPacketID; i++ {
+	for i := uint32(0); i <= cl.ops.options.Capabilities.maximumPacketID; i++ {
 		cl.State.Inflight.Set(packets.Packet{PacketID: uint16(i)})
 	}
 
@@ -1654,7 +1656,7 @@ func TestPublishToSubscribersExhaustedPacketIDs(t *testing.T) {
 	s := newServer()
 	cl, r, w := newTestClient()
 	s.Clients.Add(cl)
-	for i := uint32(0); i <= cl.ops.capabilities.maximumPacketID; i++ {
+	for i := uint32(0); i <= cl.ops.options.Capabilities.maximumPacketID; i++ {
 		cl.State.Inflight.Set(packets.Packet{PacketID: 1})
 	}
 


### PR DESCRIPTION
Addresses #189 by making the client bufio.Reader and bufio.Writer sizes configurable as server options.

The new default value for the reader and writer buffers is 2048. Different values can be configured as such:

```go
server := mqtt.New(&mqtt.Options{
    ClientNetWriteBufferSize: 1024,
    ClientNetReadBufferSize: 1024,
})
```

