### PR TITLE
Lock on close outbound

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -356,6 +356,9 @@ func (cl *Client) Read(packetHandler ReadFn) error {
 // Stop instructs the client to shut down all processing goroutines and disconnect.
 func (cl *Client) Stop(err error) {
 	cl.State.endOnce.Do(func() {
+		cl.Lock()
+		defer cl.Unlock()
+
 		if cl.Net.Conn != nil {
 			_ = cl.Net.Conn.Close() // omit close error
 		}
@@ -479,14 +482,6 @@ func (cl *Client) ReadPacket(fh *packets.FixedHeader) (pk packets.Packet, err er
 
 // WritePacket encodes and writes a packet to the client.
 func (cl *Client) WritePacket(pk packets.Packet) error {
-	if atomic.LoadUint32(&cl.State.done) == 1 {
-		return ErrConnectionClosed
-	}
-
-	if cl.Net.Conn == nil {
-		return nil
-	}
-
 	if pk.Expiry > 0 {
 		pk.Properties.MessageExpiryInterval = uint32(pk.Expiry - time.Now().Unix()) // [MQTT-3.3.2-6]
 	}
@@ -550,9 +545,18 @@ func (cl *Client) WritePacket(pk packets.Packet) error {
 		return packets.ErrPacketTooLarge // [MQTT-3.1.2-24] [MQTT-3.1.2-25]
 	}
 
-	nb := net.Buffers{buf.Bytes()}
 	cl.Lock()
 	defer cl.Unlock()
+
+	if atomic.LoadUint32(&cl.State.done) == 1 {
+		return ErrConnectionClosed
+	}
+
+	if cl.Net.Conn == nil {
+		return nil
+	}
+
+	nb := net.Buffers{buf.Bytes()}
 	n, err := nb.WriteTo(cl.Net.Conn)
 	if err != nil {
 		return err


### PR DESCRIPTION
Makes a small change to refactor the lock introduced in #212 to also lock when the outbound channel is closed, to prevent concurrency issues when trying to write to a channel which has already been closed (per #202)