### PR TITLE
Use context to exit WriteLoop

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -145,7 +145,8 @@ type ClientState struct {
 	endOnce         sync.Once            // only end once
 	isTakenOver     uint32               // used to identify orphaned clients
 	packetID        uint32               // the current highest packetID
-	open            context.Context      // indicate that the client is open for packet exchange
+	ctx             context.Context      // indicate that the client is open for packet exchange
+	cancel          context.CancelFunc   // cancel function for ctx
 	outboundQty     int32                // number of messages currently in the outbound queue
 	Keepalive       uint16               // the number of seconds the connection can wait
 	ServerKeepalive bool                 // keepalive was set by the server
@@ -154,12 +155,14 @@ type ClientState struct {
 // newClient returns a new instance of Client. This is almost exclusively used by Server
 // for creating new clients, but it lives here because it's not dependent.
 func newClient(c net.Conn, o *ops) *Client {
+	ctx, cancel := context.WithCancel(context.Background())
 	cl := &Client{
 		State: ClientState{
 			Inflight:      NewInflights(),
 			Subscriptions: NewSubscriptions(),
 			TopicAliases:  NewTopicAliases(o.options.Capabilities.TopicAliasMaximum),
-			open:          context.Background(),
+			ctx:           ctx,
+			cancel:        cancel,
 			Keepalive:     defaultKeepalive,
 			outbound:      make(chan *packets.Packet, o.options.Capabilities.MaximumClientWritesPending),
 		},
@@ -185,11 +188,16 @@ func newClient(c net.Conn, o *ops) *Client {
 
 // WriteLoop ranges over pending outbound messages and writes them to the client connection.
 func (cl *Client) WriteLoop() {
-	for pk := range cl.State.outbound {
-		if err := cl.WritePacket(*pk); err != nil {
-			cl.ops.log.Debug().Err(err).Str("client", cl.ID).Interface("packet", pk).Msg("failed publishing packet")
+	for {
+		select {
+		case pk := <-cl.State.outbound:
+			if err := cl.WritePacket(*pk); err != nil {
+				cl.ops.log.Debug().Err(err).Str("client", cl.ID).Interface("packet", pk).Msg("failed publishing packet")
+			}
+			atomic.AddInt32(&cl.State.outboundQty, -1)
+		case <-cl.State.ctx.Done():
+			return
 		}
-		atomic.AddInt32(&cl.State.outboundQty, -1)
 	}
 }
 
@@ -350,8 +358,6 @@ func (cl *Client) Read(packetHandler ReadFn) error {
 // Stop instructs the client to shut down all processing goroutines and disconnect.
 func (cl *Client) Stop(err error) {
 	cl.State.endOnce.Do(func() {
-		cl.Lock()
-		defer cl.Unlock()
 
 		if cl.Net.Conn != nil {
 			_ = cl.Net.Conn.Close() // omit close error
@@ -361,15 +367,7 @@ func (cl *Client) Stop(err error) {
 			cl.State.stopCause.Store(err)
 		}
 
-		if cl.State.outbound != nil {
-			close(cl.State.outbound)
-		}
-
-		if cl.State.open != nil {
-			var cancel context.CancelFunc
-			cl.State.open, cancel = context.WithCancel(cl.State.open)
-			cancel()
-		}
+		cl.State.cancel()
 
 		atomic.StoreInt64(&cl.State.disconnected, time.Now().Unix())
 	})
@@ -385,7 +383,7 @@ func (cl *Client) StopCause() error {
 
 // Closed returns true if client connection is closed.
 func (cl *Client) Closed() bool {
-	return cl.State.open == nil || cl.State.open.Err() != nil
+	return cl.State.ctx.Err() != nil
 }
 
 // ReadFixedHeader reads in the values of the next packet's fixed header.

--- a/clients_test.go
+++ b/clients_test.go
@@ -467,7 +467,7 @@ func TestClientReadOK(t *testing.T) {
 func TestClientReadDone(t *testing.T) {
 	cl, _, _ := newTestClient()
 	defer cl.Stop(errClientStop)
-	cl.State.open = nil
+	cl.State.canelOpen()
 
 	o := make(chan error)
 	go func() {

--- a/server_test.go
+++ b/server_test.go
@@ -2821,7 +2821,7 @@ func TestServerClearExpiredClients(t *testing.T) {
 	cl0, _, _ := newTestClient()
 	cl0.ID = "c0"
 	cl0.State.disconnected = n - 10
-	cl0.State.open = nil
+	cl0.State.canelOpen()
 	cl0.Properties.ProtocolVersion = 5
 	cl0.Properties.Props.SessionExpiryInterval = 12
 	cl0.Properties.Props.SessionExpiryIntervalFlag = true
@@ -2831,7 +2831,7 @@ func TestServerClearExpiredClients(t *testing.T) {
 	cl1, _, _ := newTestClient()
 	cl1.ID = "c1"
 	cl1.State.disconnected = n - 10
-	cl1.State.open = nil
+	cl1.State.canelOpen()
 	cl1.Properties.ProtocolVersion = 5
 	cl1.Properties.Props.SessionExpiryInterval = 8
 	cl1.Properties.Props.SessionExpiryIntervalFlag = true
@@ -2841,7 +2841,7 @@ func TestServerClearExpiredClients(t *testing.T) {
 	cl2, _, _ := newTestClient()
 	cl2.ID = "c2"
 	cl2.State.disconnected = n - 10
-	cl2.State.open = nil
+	cl2.State.canelOpen()
 	cl2.Properties.ProtocolVersion = 5
 	cl2.Properties.Props.SessionExpiryInterval = 0
 	cl2.Properties.Props.SessionExpiryIntervalFlag = true


### PR DESCRIPTION
This is the PR for #221. By using context to exit WriteLoop, we no longer need to close the outbound chan.

This also impacts:
* #202 
* #191 
