### PR TITLE
Expose SendConnack, err return on OnConnect

### DIFF
--- a/examples/hooks/main.go
+++ b/examples/hooks/main.go
@@ -110,8 +110,9 @@ func (h *ExampleHook) Init(config any) error {
 	return nil
 }
 
-func (h *ExampleHook) OnConnect(cl *mqtt.Client, pk packets.Packet) {
+func (h *ExampleHook) OnConnect(cl *mqtt.Client, pk packets.Packet) error {
 	h.Log.Info().Str("client", cl.ID).Msgf("client connected")
+	return nil
 }
 
 func (h *ExampleHook) OnDisconnect(cl *mqtt.Client, err error, expire bool) {

--- a/examples/paho.testing/main.go
+++ b/examples/paho.testing/main.go
@@ -73,10 +73,11 @@ func (h *pahoAuthHook) OnACLCheck(cl *mqtt.Client, topic string, write bool) boo
 	return topic != "test/nosubscribe"
 }
 
-func (h *pahoAuthHook) OnConnect(cl *mqtt.Client, pk packets.Packet) {
+func (h *pahoAuthHook) OnConnect(cl *mqtt.Client, pk packets.Packet) error {
 	// Handle paho test_server_keep_alive
 	if pk.Connect.Keepalive == 120 && pk.Connect.Clean {
 		cl.State.Keepalive = 60
 		cl.State.ServerKeepalive = true
 	}
+	return nil
 }


### PR DESCRIPTION
Exposes the `func (s *Server) SendConnack(cl *Client, reason packets.Code, present bool, properties *packets.Properties) error` method to allow developers to properly formed SendConnack packets directly. Adds a `err` return value to `OnConnect` allowing developers to halt the connection process.