### PR TITLE
Add healthcheck listener

### DIFF
--- a/listeners/http_healthcheck.go
+++ b/listeners/http_healthcheck.go
@@ -1,0 +1,100 @@
+package listeners
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// HTTPHealthCheck is a listener for presenting the server $SYS stats on a JSON http endpoint.
+type HTTPHealthCheck struct {
+	sync.RWMutex
+	id      string          // the internal id of the listener
+	address string          // the network address to bind to
+	config  *Config         // configuration values for the listener
+	listen  *http.Server    // the http server
+	log     *zerolog.Logger // server logger
+	end     uint32          // ensure the close methods are only called once
+}
+
+// NewHTTPHealthCheck initialises and returns a new HTTP listener, listening on an address.
+func NewHTTPHealthCheck(id, address string, config *Config) *HTTPHealthCheck {
+	if config == nil {
+		config = new(Config)
+	}
+	return &HTTPHealthCheck{
+		id:      id,
+		address: address,
+		config:  config,
+	}
+}
+
+// ID returns the id of the listener.
+func (l *HTTPHealthCheck) ID() string {
+	return l.id
+}
+
+// Address returns the address of the listener.
+func (l *HTTPHealthCheck) Address() string {
+	return l.address
+}
+
+// Protocol returns the address of the listener.
+func (l *HTTPHealthCheck) Protocol() string {
+	if l.listen != nil && l.listen.TLSConfig != nil {
+		return "https"
+	}
+
+	return "http"
+}
+
+// Init initializes the listener.
+func (l *HTTPHealthCheck) Init(log *zerolog.Logger) error {
+	l.log = log
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	l.listen = &http.Server{
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		Addr:         l.address,
+		Handler:      mux,
+	}
+
+	if l.config.TLSConfig != nil {
+		l.listen.TLSConfig = l.config.TLSConfig
+	}
+
+	return nil
+}
+
+// Serve starts listening for new connections and serving responses.
+func (l *HTTPHealthCheck) Serve(establish EstablishFn) {
+	if l.listen.TLSConfig != nil {
+		l.listen.ListenAndServeTLS("", "")
+	} else {
+		l.listen.ListenAndServe()
+	}
+}
+
+// Close closes the listener and any client connections.
+func (l *HTTPHealthCheck) Close(closeClients CloseFn) {
+	l.Lock()
+	defer l.Unlock()
+
+	if atomic.CompareAndSwapUint32(&l.end, 0, 1) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		l.listen.Shutdown(ctx)
+	}
+
+	closeClients(l.id)
+}

--- a/listeners/http_healthcheck.go
+++ b/listeners/http_healthcheck.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// HTTPHealthCheck is a listener for presenting the server $SYS stats on a JSON http endpoint.
+// HTTPHealthCheck is a listener for providing an HTTP healthcheck endpoint.
 type HTTPHealthCheck struct {
 	sync.RWMutex
 	id      string          // the internal id of the listener

--- a/listeners/http_healthcheck_test.go
+++ b/listeners/http_healthcheck_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 mochi-co
+// SPDX-FileContributor: mochi-co
+
+package listeners
+
+import (
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPHealthCheck(t *testing.T) {
+	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	require.Equal(t, "healthcheck", l.id)
+	require.Equal(t, testAddr, l.address)
+}
+
+func TestHTTPHealthCheckID(t *testing.T) {
+	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	require.Equal(t, "healthcheck", l.ID())
+}
+
+func TestHTTPHealthCheckAddress(t *testing.T) {
+	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	require.Equal(t, testAddr, l.Address())
+}
+
+func TestHTTPHealthCheckProtocol(t *testing.T) {
+	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	require.Equal(t, "http", l.Protocol())
+}
+
+func TestHTTPHealthCheckTLSProtocol(t *testing.T) {
+	l := NewHTTPHealthCheck("healthcheck", testAddr, &Config{
+		TLSConfig: tlsConfigBasic,
+	})
+
+	l.Init(nil)
+	require.Equal(t, "https", l.Protocol())
+}
+
+func TestHTTPHealthCheckInit(t *testing.T) {
+	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	err := l.Init(nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, l.listen)
+	require.Equal(t, testAddr, l.listen.Addr)
+}
+
+func TestHTTPHealthCheckServeAndClose(t *testing.T) {
+	// setup http stats listener
+	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	err := l.Init(nil)
+	require.NoError(t, err)
+
+	o := make(chan bool)
+	go func(o chan bool) {
+		l.Serve(MockEstablisher)
+		o <- true
+	}(o)
+
+	time.Sleep(time.Millisecond)
+
+	// get body from stats address
+	resp, err := http.Get("http://localhost" + testAddr + "/healthcheck")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	defer resp.Body.Close()
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// ensure listening is closed
+	var closed bool
+	l.Close(func(id string) {
+		closed = true
+	})
+
+	require.Equal(t, true, closed)
+
+	_, err = http.Get("http://localhost/healthcheck" + testAddr + "/healthcheck")
+	require.Error(t, err)
+	<-o
+}
+
+func TestHTTPHealthCheckServeAndCloseMethodNotAllowed(t *testing.T) {
+	// setup http stats listener
+	l := NewHTTPHealthCheck("healthcheck", testAddr, nil)
+	err := l.Init(nil)
+	require.NoError(t, err)
+
+	o := make(chan bool)
+	go func(o chan bool) {
+		l.Serve(MockEstablisher)
+		o <- true
+	}(o)
+
+	time.Sleep(time.Millisecond)
+
+	// get body from stats address
+	resp, err := http.Post("http://localhost"+testAddr+"/healthcheck", "application/json", http.NoBody)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	defer resp.Body.Close()
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// ensure listening is closed
+	var closed bool
+	l.Close(func(id string) {
+		closed = true
+	})
+
+	require.Equal(t, true, closed)
+
+	_, err = http.Post("http://localhost/healthcheck"+testAddr+"/healthcheck", "application/json", http.NoBody)
+	require.Error(t, err)
+	<-o
+}
+
+func TestHTTPHealthCheckServeTLSAndClose(t *testing.T) {
+	l := NewHTTPHealthCheck("healthcheck", testAddr, &Config{
+		TLSConfig: tlsConfigBasic,
+	})
+
+	err := l.Init(nil)
+	require.NoError(t, err)
+
+	o := make(chan bool)
+	go func(o chan bool) {
+		l.Serve(MockEstablisher)
+		o <- true
+	}(o)
+
+	time.Sleep(time.Millisecond)
+	l.Close(MockCloser)
+}

--- a/listeners/http_healthcheck_test.go
+++ b/listeners/http_healthcheck_test.go
@@ -66,7 +66,7 @@ func TestHTTPHealthCheckServeAndClose(t *testing.T) {
 
 	time.Sleep(time.Millisecond)
 
-	// get body from stats address
+	// call healthcheck
 	resp, err := http.Get("http://localhost" + testAddr + "/healthcheck")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -102,7 +102,7 @@ func TestHTTPHealthCheckServeAndCloseMethodNotAllowed(t *testing.T) {
 
 	time.Sleep(time.Millisecond)
 
-	// get body from stats address
+	// make disallowed method type http request
 	resp, err := http.Post("http://localhost"+testAddr+"/healthcheck", "application/json", http.NoBody)
 	require.NoError(t, err)
 	require.NotNil(t, resp)


### PR DESCRIPTION
This commit adds an HTTP healthcheck listener. This is done to allow the broker to comply with certain requirements by cloud providers for certain scaling and container monitoring if required by the provider. For example, [GCP External Passthrough Network Load Balancer](https://cloud.google.com/load-balancing/docs/network)