### PR TITLE
WriterSize parameter is incorrectly set

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -177,7 +177,7 @@ func newClient(c net.Conn, o *ops) *Client {
 			Conn: c,
 			bconn: bufio.NewReadWriter(
 				bufio.NewReaderSize(c, o.options.ClientNetReadBufferSize),
-				bufio.NewWriterSize(c, o.options.ClientNetReadBufferSize),
+				bufio.NewWriterSize(c, o.options.ClientNetWriteBufferSize),
 			),
 			Remote: c.RemoteAddr().String(),
 		}


### PR DESCRIPTION
The WriterSize parameter is incorrectly set in the newClient method.