### PR TITLE
Ensure msg doesn't exceed subscription QoS

### DIFF
--- a/server.go
+++ b/server.go
@@ -818,6 +818,10 @@ func (s *Server) publishToClient(cl *Client, sub packets.Subscription, pk packet
 		sort.Ints(out.Properties.SubscriptionIdentifier)
 	}
 
+	if out.FixedHeader.Qos > sub.Qos {
+		out.FixedHeader.Qos = sub.Qos
+	}
+
 	if out.FixedHeader.Qos > s.Options.Capabilities.MaximumQos {
 		out.FixedHeader.Qos = s.Options.Capabilities.MaximumQos // [MQTT-3.2.2-9]
 	}


### PR DESCRIPTION
If subscriber QoS is less than the publisher QoS, downgrade delivery QoS for that subscriber.

In addition, the below code can be removed, as the during the subscription, we already check if it exceed MaxmumQos:
```go
	if out.FixedHeader.Qos > s.Options.Capabilities.MaximumQos {
		out.FixedHeader.Qos = s.Options.Capabilities.MaximumQos // [MQTT-3.2.2-9]
	}
```
