### PR TITLE
Allow Publish to return custom Ack error responses

### DIFF
--- a/examples/paho.testing/main.go
+++ b/examples/paho.testing/main.go
@@ -28,6 +28,7 @@ func main() {
 	server := mqtt.New(nil)
 	server.Options.Capabilities.Compatibilities.ObscureNotAuthorized = true
 	server.Options.Capabilities.Compatibilities.PassiveClientDisconnect = true
+	server.Options.Capabilities.Compatibilities.NoInheritedPropertiesOnAck = true
 
 	_ = server.AddHook(new(pahoAuthHook), nil)
 	tcp := listeners.NewTCP("t1", ":1883", nil)

--- a/packets/codes.go
+++ b/packets/codes.go
@@ -28,6 +28,7 @@ var (
 		2: CodeGrantedQos2,
 	}
 
+	CodeSuccessIgnore                         = Code{Code: 0x00, Reason: "ignore packet"}
 	CodeSuccess                               = Code{Code: 0x00, Reason: "success"}
 	CodeDisconnect                            = Code{Code: 0x00, Reason: "disconnected"}
 	CodeGrantedQos0                           = Code{Code: 0x00, Reason: "granted qos 0"}

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -135,6 +135,7 @@ type Packet struct {
 	SessionPresent  bool          // session existed for connack
 	ReasonCode      byte          // reason code for a packet response (acks, etc)
 	ReservedBit     byte          // reserved, do not use (except in testing)
+	Ignore          bool          // if true, do not perform any message forwarding operations
 }
 
 // Mods specifies certain values required for certain mqtt v5 compliance within packet encoding/decoding.

--- a/packets/tpackets.go
+++ b/packets/tpackets.go
@@ -103,6 +103,7 @@ const (
 	TPublishBasicMqtt5
 	TPublishMqtt5
 	TPublishQos1
+	TPublishQos1Mqtt5
 	TPublishQos1NoPayload
 	TPublishQos1Dup
 	TPublishQos2
@@ -1705,6 +1706,43 @@ var TPacketData = map[byte]TPacketCases{
 				PacketID:  7,
 			},
 		},
+		{
+            Case:    TPublishQos1Mqtt5,
+            Desc:    "mqtt v5",
+            Primary: true,
+            RawBytes: []byte{
+                Publish<<4 | 1<<1, 37, // Fixed header
+                0, 5, // Topic Name - LSB+MSB
+                'a', '/', 'b', '/', 'c', // Topic Name
+                0, 7, // Packet ID - LSB+MSB
+                // Properties
+                16, // length
+                38, // User Properties (38)
+                0, 5, 'h', 'e', 'l', 'l', 'o',
+                0, 6, 228, 184, 150, 231, 149, 140,
+                'h', 'e', 'l', 'l', 'o', ' ', 'm', 'o', 'c', 'h', 'i', // Payload
+            },
+            Packet: &Packet{
+                ProtocolVersion: 5,
+                FixedHeader: FixedHeader{
+                    Type:      Publish,
+                    Remaining: 37,
+                    Qos:       1,
+                },
+                PacketID:  7,
+                TopicName: "a/b/c",
+                Properties: Properties{
+                    User: []UserProperty{
+                        {
+                            Key: "hello",
+                            Val: "世界",
+                        },
+                    },
+                },
+                Payload: []byte("hello mochi"),
+            },
+        },
+
 		{
 			Case:    TPublishQos1Dup,
 			Desc:    "qos:1, dup:true, packet id",

--- a/server_test.go
+++ b/server_test.go
@@ -1266,7 +1266,7 @@ func TestServerProcessPacketAndNextImmediate(t *testing.T) {
 	require.Equal(t, int32(4), cl.State.Inflight.sendQuota)
 }
 
-func TestServerProcessPacketPublishAckFailure(t *testing.T) {
+func TestServerProcessPublishAckFailure(t *testing.T) {
 	s := newServer()
 	s.Serve()
 	defer s.Close()
@@ -1278,6 +1278,92 @@ func TestServerProcessPacketPublishAckFailure(t *testing.T) {
 	err := s.processPublish(cl, *packets.TPacketData[packets.Publish].Get(packets.TPublishQos2).Packet)
 	require.Error(t, err)
 	require.ErrorIs(t, err, io.ErrClosedPipe)
+}
+
+func TestServerProcessPublishOnPublishAckErrorRWError(t *testing.T) {
+	s := newServer()
+	hook := new(modifiedHookBase)
+    hook.fail = true
+	hook.err = packets.ErrUnspecifiedError
+    err := s.AddHook(hook, nil)
+	require.NoError(t,err)
+
+	cl, _, w := newTestClient()
+	cl.Properties.ProtocolVersion = 5
+	s.Clients.Add(cl)
+	w.Close()
+
+	err = s.processPublish(cl, *packets.TPacketData[packets.Publish].Get(packets.TPublishQos1).Packet)
+	require.Error(t, err)
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+}
+
+func TestServerProcessPublishOnPublishAckErrorContinue(t *testing.T) {
+	s := newServer()
+	hook := new(modifiedHookBase)
+    hook.fail = true
+    hook.err = packets.ErrPayloadFormatInvalid
+    err := s.AddHook(hook, nil)
+    require.NoError(t,err)
+	s.Serve()
+	defer s.Close()
+
+	cl, r, w := newTestClient()
+	cl.Properties.ProtocolVersion = 5
+	s.Clients.Add(cl)
+
+	go func() {
+		err := s.processPacket(cl, *packets.TPacketData[packets.Publish].Get(packets.TPublishQos1).Packet)
+		require.NoError(t, err)
+		w.Close()
+	}()
+
+	buf, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, packets.TPacketData[packets.Puback].Get(packets.TPubackUnexpectedError).RawBytes, buf)
+}
+
+func TestServerProcessPublishOnPublishPkIgnore(t *testing.T) {
+	s := newServer()
+	hook := new(modifiedHookBase)
+    hook.fail = true
+    hook.err = packets.CodeSuccessIgnore
+    err := s.AddHook(hook, nil)
+    require.NoError(t,err)
+	s.Serve()
+	defer s.Close()
+
+	cl, r, w := newTestClient()
+	s.Clients.Add(cl)
+
+	receiver, r2, w2 := newTestClient()
+    receiver.ID = "receiver"
+    s.Clients.Add(receiver)
+    s.Topics.Subscribe(receiver.ID, packets.Subscription{Filter: "a/b/c"})
+
+    require.Equal(t, int64(0), atomic.LoadInt64(&s.Info.PacketsReceived))
+    require.Equal(t, 0, len(s.Topics.Messages("a/b/c")))
+
+    receiverBuf := make(chan []byte)
+    go func() {
+        buf, err := io.ReadAll(r2)
+        require.NoError(t, err)
+        receiverBuf <- buf
+    }()
+
+
+	go func() {
+		err := s.processPacket(cl, *packets.TPacketData[packets.Publish].Get(packets.TPublishQos1).Packet)
+		require.NoError(t, err)
+		w.Close()
+		w2.Close()
+	}()
+
+	buf, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, packets.TPacketData[packets.Puback].Get(packets.TPuback).RawBytes, buf)
+	require.Equal(t, []byte{}, <-receiverBuf)
+	require.Equal(t, 0, len(s.Topics.Messages("a/b/c")))
 }
 
 func TestServerProcessPacketPublishMaximumReceive(t *testing.T) {
@@ -1337,27 +1423,6 @@ func TestServerProcessPublishOnMessageRecvRejected(t *testing.T) {
 	cl, _, _ := newTestClient()
 	err = s.processPublish(cl, *packets.TPacketData[packets.Publish].Get(packets.TPublishBasic).Packet)
 	require.NoError(t, err) // packets rejected silently
-}
-
-func TestServerProcessPublishOnPublishErrorToAck(t *testing.T) {
-	s := newServer()
-	hook := new(modifiedHookBase)
-	hook.fail = true
-	hook.err = packets.ErrPayloadFormatInvalid
-	err := s.AddHook(hook, nil)
-	require.NoError(t, err)
-
-	cl, r, w := newTestClient()
-	cl.Properties.ProtocolVersion = 5
-	go func() {
-		err := s.processPacket(cl, *packets.TPacketData[packets.Publish].Get(packets.TPublishQos1).Packet)
-		require.Error(t, err)
-		w.Close()
-	}()
-
-	buf, err := io.ReadAll(r)
-	require.NoError(t, err)
-	require.Equal(t, packets.TPacketData[packets.Puback].Get(packets.TPubackUnexpectedError).RawBytes, buf)
 }
 
 func TestServerProcessPacketPublishQos0(t *testing.T) {
@@ -1457,6 +1522,7 @@ func TestServerProcessPacketPublishDowngradeQos(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, packets.TPacketData[packets.Puback].Get(packets.TPuback).RawBytes, buf)
 }
+
 
 func TestPublishToSubscribersSelfNoLocal(t *testing.T) {
 	s := newServer()
@@ -1601,6 +1667,32 @@ func TestPublishToSubscribersIdentifiers(t *testing.T) {
 
 	require.Equal(t, packets.TPacketData[packets.Publish].Get(packets.TPublishSubscriberIdentifier).RawBytes, <-receiverBuf)
 }
+
+func TestPublishToSubscribersPkIgnore(t *testing.T) {
+	s := newServer()
+	cl, r, w := newTestClient()
+	s.Clients.Add(cl)
+	subbed := s.Topics.Subscribe(cl.ID, packets.Subscription{Filter: "#", Identifier: 1})
+	require.True(t, subbed)
+
+	go func() {
+		pk := *packets.TPacketData[packets.Publish].Get(packets.TPublishBasic).Packet
+		pk.Ignore = true
+		s.publishToSubscribers(pk)
+		time.Sleep(time.Millisecond)
+		w.Close()
+	}()
+
+	receiverBuf := make(chan []byte)
+	go func() {
+		buf, err := io.ReadAll(r)
+		require.NoError(t, err)
+		receiverBuf <- buf
+	}()
+
+	require.Equal(t, []byte{}, <-receiverBuf)
+}
+
 
 func TestPublishToClientServerDowngradeQos(t *testing.T) {
 	s := newServer()
@@ -1909,6 +2001,27 @@ func TestNoRetainMessageIfUnavailable(t *testing.T) {
 
 	s.retainMessage(new(Client), *packets.TPacketData[packets.Publish].Get(packets.TPublishRetain).Packet)
 	require.Equal(t, int64(0), atomic.LoadInt64(&s.Info.Retained))
+}
+
+
+func TestNoRetainMessageIfPkIgnore(t *testing.T) {
+	s := newServer()
+	cl, _, _ := newTestClient()
+	s.Clients.Add(cl)
+
+	pk := *packets.TPacketData[packets.Publish].Get(packets.TPublishRetain).Packet
+	pk.Ignore = true
+	s.retainMessage(new(Client), pk)
+	require.Equal(t, int64(0), atomic.LoadInt64(&s.Info.Retained))
+}
+
+func TestNoRetainMessage(t *testing.T) {
+	s := newServer()
+	cl, _, _ := newTestClient()
+	s.Clients.Add(cl)
+
+	s.retainMessage(new(Client),  *packets.TPacketData[packets.Publish].Get(packets.TPublishRetain).Packet)
+	require.Equal(t, int64(1), atomic.LoadInt64(&s.Info.Retained))
 }
 
 func TestServerProcessPacketPuback(t *testing.T) {


### PR DESCRIPTION
Following a discussion in #249, it became apparent that we do not currently return packet errors in acks when a received publish packet is invalid (or an error has been returned by the OnPublish hook), which is a behaviour indicated in the MQTT v5 specification. 

This PR adds a check statement to return an error ack if the client is v5, the error is a packet error (not a 'true error'), and the Qos > 0. 

Additionally, a line has been corrected allowing the User Properties to be propagated to the ack, as per the spec (formerly this would be dropped). As such, a compatibility mode has been added to bypass a spec violation in the paho interoperability library which expects no user properties. We should consider migrating away from the paho testing library.

Otherwise passing Paho and Unit tests.

I can't seem to add anyone for review, so @thedevop @wind-c @dgduncan, if you could give this a look over, I would be grateful 🙏🏻 