### PR TITLE
Retain flag should be delivered as false in v3

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -175,6 +175,7 @@ type Subscription struct {
 	Qos               byte
 	RetainAsPublished bool
 	NoLocal           bool
+	FwdRetainedFlag   bool // true if the subscription forms part of a publish response to a client subscription and packet is retained.
 }
 
 // Copy creates a new instance of a packet, but with an empty header for inheriting new QoS flags, etc.
@@ -387,7 +388,7 @@ func (pk *Packet) ConnectDecode(buf []byte) error {
 		offset += n
 	}
 
-	pk.Connect.ClientIdentifier, offset, err = decodeString(buf, offset) //[MQTT-3.1.3-1] [MQTT-3.1.3-2] [MQTT-3.1.3-3] [MQTT-3.1.3-4]
+	pk.Connect.ClientIdentifier, offset, err = decodeString(buf, offset) // [MQTT-3.1.3-1] [MQTT-3.1.3-2] [MQTT-3.1.3-3] [MQTT-3.1.3-4]
 	if err != nil {
 		return ErrClientIdentifierNotValid // [MQTT-3.1.3-8]
 	}

--- a/server.go
+++ b/server.go
@@ -806,7 +806,7 @@ func (s *Server) publishToClient(cl *Client, sub packets.Subscription, pk packet
 	}
 
 	out := pk.Copy(false)
-	if cl.Properties.ProtocolVersion == 5 && !sub.RetainAsPublished { // ![MQTT-3.3.1-13]
+	if (cl.Properties.ProtocolVersion == 5 && !sub.RetainAsPublished) || cl.Properties.ProtocolVersion < 5 { // ![MQTT-3.3.1-13] [v3 MQTT-3.3.1-9]
 		out.FixedHeader.Retain = false // [MQTT-3.3.1-12]
 	}
 

--- a/server.go
+++ b/server.go
@@ -806,7 +806,7 @@ func (s *Server) publishToClient(cl *Client, sub packets.Subscription, pk packet
 	}
 
 	out := pk.Copy(false)
-	if (cl.Properties.ProtocolVersion == 5 && !sub.RetainAsPublished) || cl.Properties.ProtocolVersion < 5 { // ![MQTT-3.3.1-13] [v3 MQTT-3.3.1-9]
+	if !sub.FwdRetainedFlag && ((cl.Properties.ProtocolVersion == 5 && !sub.RetainAsPublished) || cl.Properties.ProtocolVersion < 5) { // ![MQTT-3.3.1-13] [v3 MQTT-3.3.1-9]
 		out.FixedHeader.Retain = false // [MQTT-3.3.1-12]
 	}
 
@@ -888,6 +888,7 @@ func (s *Server) publishRetainedToClient(cl *Client, sub packets.Subscription, e
 		return
 	}
 
+	sub.FwdRetainedFlag = true
 	for _, pkv := range s.Topics.Messages(sub.Filter) { // [MQTT-3.8.4-4]
 		_, err := s.publishToClient(cl, sub, pkv)
 		if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -1798,7 +1798,7 @@ func TestPublishRetainedToClient(t *testing.T) {
 
 	buf, err := io.ReadAll(r)
 	require.NoError(t, err)
-	require.Equal(t, packets.TPacketData[packets.Publish].Get(packets.TPublishBasic).RawBytes, buf)
+	require.Equal(t, packets.TPacketData[packets.Publish].Get(packets.TPublishRetain).RawBytes, buf)
 }
 
 func TestPublishRetainedToClientIsShared(t *testing.T) {
@@ -2316,7 +2316,7 @@ func TestServerProcessSubscribeWithRetain(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, append(
 		packets.TPacketData[packets.Suback].Get(packets.TSuback).RawBytes,
-		packets.TPacketData[packets.Publish].Get(packets.TPublishBasic).RawBytes...,
+		packets.TPacketData[packets.Publish].Get(packets.TPublishRetain).RawBytes...,
 	), buf)
 }
 
@@ -2401,7 +2401,7 @@ func TestServerProcessSubscribeWithNotRetainAsPublished(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, append(
 		packets.TPacketData[packets.Suback].Get(packets.TSuback).RawBytes,
-		packets.TPacketData[packets.Publish].Get(packets.TPublishBasic).RawBytes...,
+		packets.TPacketData[packets.Publish].Get(packets.TPublishRetain).RawBytes...,
 	), buf)
 }
 


### PR DESCRIPTION
Per @bkupidura's note in #251, the retain flag was incorrectly being transmitted as set to MQTTv3 clients. For MQTTv3, the retain flag should be delivered as 'false' after being stored.

This PR adds a correction to this behaviour, and adjusts any tests implementing v3 retain accordingly

cc @bkupidura @thedevop @dgduncan @wind-c - if anyone wishes to review :) 