### PR TITLE
Do not retain messages if retain is not available

### DIFF
--- a/server.go
+++ b/server.go
@@ -764,6 +764,10 @@ func (s *Server) processPublish(cl *Client, pk packets.Packet) error {
 // retainMessage adds a message to a topic, and if a persistent store is provided,
 // adds the message to the store to be reloaded if necessary.
 func (s *Server) retainMessage(cl *Client, pk packets.Packet) {
+	if s.Options.Capabilities.RetainAvailable == 0 {
+		return
+	}
+
 	out := pk.Copy(false)
 	r := s.Topics.RetainMessage(out)
 	s.hooks.OnRetainMessage(cl, pk, r)

--- a/server_test.go
+++ b/server_test.go
@@ -1813,6 +1813,16 @@ func TestPublishRetainedToClientError(t *testing.T) {
 	s.publishRetainedToClient(cl, sub, false)
 }
 
+func TestNoRetainMessageIfUnavailable(t *testing.T) {
+	s := newServer()
+	s.Options.Capabilities.RetainAvailable = 0
+	cl, _, _ := newTestClient()
+	s.Clients.Add(cl)
+
+	s.retainMessage(new(Client), *packets.TPacketData[packets.Publish].Get(packets.TPublishRetain).Packet)
+	require.Equal(t, int64(0), atomic.LoadInt64(&s.Info.Retained))
+}
+
 func TestServerProcessPacketPuback(t *testing.T) {
 	tt := ProtocolTest{
 		{


### PR DESCRIPTION
Following #255, I noticed that `s.Options.Capabilities.RetainAvailable` is advisory only - it only indicates to the client that retain is unavailable, but does not actually disable the feature. This PR prevents messages from being retained if `s.Options.Capabilities.RetainAvailable = 0`.