### PR TITLE
method UnsubscribeClient's packet add fixedHeader

### DIFF
--- a/server.go
+++ b/server.go
@@ -1144,7 +1144,7 @@ func (s *Server) UnsubscribeClient(cl *Client) {
 		filters[i] = v
 		i++
 	}
-	s.hooks.OnUnsubscribed(cl, packets.Packet{Filters: filters})
+	s.hooks.OnUnsubscribed(cl, packets.Packet{FixedHeader: packets.FixedHeader{Type: packets.Unsubscribe}, Filters: filters})
 }
 
 // processAuth processes an Auth packet.


### PR DESCRIPTION
When calling the OnUnsubscribed method during secondary development, the corresponding processor will be selected based on the type of the packet. However, the lack of packet type in UnsubscribeClient results in the inability to select the appropriate processor successfully.