### PR TITLE
fix issue: incorrect subscribe scene of share subscribe.

### DIFF
--- a/topics.go
+++ b/topics.go
@@ -251,10 +251,16 @@ type Subscribers struct {
 	Subscriptions  map[string]packets.Subscription
 }
 
-// SelectShared returns one subscriber for each shared subscription group.
 func (s *Subscribers) SelectShared() {
 	s.SharedSelected = map[string]packets.Subscription{}
+p1:
 	for _, subs := range s.Shared {
+		for client, _ := range subs {
+			if _, ok := s.Subscriptions[client]; ok {
+				continue p1
+			}
+		}
+
 		for client, sub := range subs {
 			cls, ok := s.SharedSelected[client]
 			if !ok {

--- a/topics.go
+++ b/topics.go
@@ -251,6 +251,7 @@ type Subscribers struct {
 	Subscriptions  map[string]packets.Subscription
 }
 
+// SelectShared returns one subscriber for each shared subscription group.
 func (s *Subscribers) SelectShared() {
 	s.SharedSelected = map[string]packets.Subscription{}
 p1:

--- a/topics_test.go
+++ b/topics_test.go
@@ -554,6 +554,7 @@ func TestSelectSharedSubscriber(t *testing.T) {
 	index.Subscribe("cl1b", packets.Subscription{Qos: 0, Filter: SharePrefix + "/tmp/a/b/c", Identifier: 111})
 	index.Subscribe("cl2", packets.Subscription{Qos: 0, Filter: SharePrefix + "/tmp/a/b/c", Identifier: 112})
 	index.Subscribe("cl3", packets.Subscription{Qos: 0, Filter: SharePrefix + "/tmp2/a/b/c", Identifier: 113})
+	index.Subscribe("cl1", packets.Subscription{Qos: 0, Filter: "a/b/c", Identifier: 114})
 	subs := index.scanSubscribers("a/b/c", 0, nil, new(Subscribers))
 	require.Equal(t, 2, len(subs.Shared))
 	require.Contains(t, subs.Shared, SharePrefix+"/tmp/a/b/c")
@@ -561,7 +562,7 @@ func TestSelectSharedSubscriber(t *testing.T) {
 	require.Len(t, subs.Shared[SharePrefix+"/tmp/a/b/c"], 3)
 	require.Len(t, subs.Shared[SharePrefix+"/tmp2/a/b/c"], 1)
 	subs.SelectShared()
-	require.Len(t, subs.SharedSelected, 2)
+	require.Len(t, subs.SharedSelected, 1)
 }
 
 func TestMergeSharedSelected(t *testing.T) {


### PR DESCRIPTION
scene:
cl1 subscribe with filters: $SHARE/g1/a/b/c; a/b/c
cl2 subscribe with filter: $SHARE/g1/a/b/c
cl3 publish a message with topic a/b/c through broker. 

actully: cl1 always receive message. but sometimes cl2 receive message. 
correct: cl2 never receive message. cl1 receive message.

I have a test on emqx. it's correct, cl2 never receve message.

@mochi-co please review.